### PR TITLE
Remove dependency on regex package

### DIFF
--- a/.release-notes/dep-removal.md
+++ b/.release-notes/dep-removal.md
@@ -1,0 +1,3 @@
+# Remove regex dependency
+
+Templates no longer depends on the regex package.

--- a/corral.json
+++ b/corral.json
@@ -5,10 +5,6 @@
       "version": "0.1.1"
     },
     {
-      "locator": "github.com/ponylang/regex.git",
-      "version": "1.1.2"
-    },
-    {
       "locator": "github.com/ponylang/valbytes.git",
       "version": "0.6.0"
     }

--- a/lock.json
+++ b/lock.json
@@ -5,10 +5,6 @@
       "revision": "0.1.1"
     },
     {
-      "locator": "github.com/ponylang/regex.git",
-      "revision": "1.1.2"
-    },
-    {
       "locator": "github.com/ponylang/valbytes.git",
       "revision": "0.6.0"
     },


### PR DESCRIPTION
regex depends on libpcre2, an external library. With the dependency
removed, templates is now a pure Pony package.

Fixes #3