### PR TITLE
Update Makefile to match ponylang standard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,78 @@
+config ?= release
+
 PACKAGE := templates
 GET_DEPENDENCIES_WITH := corral fetch
 CLEAN_DEPENDENCIES_WITH := corral clean
 COMPILE_WITH := corral run -- ponyc
 
+BUILD_DIR ?= build/$(config)
+COVERAGE_DIR ?= build/coverage
 SRC_DIR ?= $(PACKAGE)
+EXAMPLES_DIR := examples
+coverage_binary := $(COVERAGE_DIR)/$(PACKAGE)
+tests_binary := $(BUILD_DIR)/$(PACKAGE)
+docs_dir := build/$(PACKAGE)-docs
+
+ifdef config
+	ifeq (,$(filter $(config),debug release))
+		$(error Unknown configuration "$(config)")
+	endif
+endif
+
+ifeq ($(config),release)
+	PONYC = $(COMPILE_WITH)
+else
+	PONYC = $(COMPILE_WITH) --debug
+endif
 
 SOURCE_FILES := $(shell find $(SRC_DIR) -name *.pony)
+EXAMPLES := $(notdir $(shell find $(EXAMPLES_DIR)/* -type d))
+EXAMPLES_SOURCE_FILES := $(shell find $(EXAMPLES_DIR) -name *.pony)
+EXAMPLES_BINARIES := $(addprefix $(BUILD_DIR)/,$(EXAMPLES))
 
-all: test docs
+test: unit-tests build-examples
 
-docs: $(SOURCE_FILES)
+unit-tests: $(tests_binary)
+	$^ --exclude=integration --sequential
+
+$(tests_binary): $(SOURCE_FILES) | $(BUILD_DIR)
 	$(GET_DEPENDENCIES_WITH)
-	$(COMPILE_WITH) --docs-public --pass=docs --output build $(SRC_DIR)
+	$(PONYC) -o $(BUILD_DIR) $(SRC_DIR)
 
-build/templates: $(SOURCE_FILES)
+build-examples: $(EXAMPLES_BINARIES)
+
+$(EXAMPLES_BINARIES): $(BUILD_DIR)/%: $(SOURCE_FILES) $(EXAMPLES_SOURCE_FILES) | $(BUILD_DIR)
 	$(GET_DEPENDENCIES_WITH)
-	$(COMPILE_WITH) -o build $(SRC_DIR)
-
-build/templates_dbg: build/templates
-	$(COMPILE_WITH) --debug -o build -b templates_dbg $(SRC_DIR)
-
-test: build/templates
-	$^
-
-build/coverage:
-	mkdir -p build/coverage
-
-coverage: build/coverage build/templates_dbg
-	kcov --include-pattern="/$(SRC_DIR)/" --exclude-pattern="/test/,_test.pony" build/coverage build/templates_dbg
+	$(PONYC) -o $(BUILD_DIR) $(EXAMPLES_DIR)/$*
 
 clean:
 	$(CLEAN_DEPENDENCIES_WITH)
-	rm -rf build
+	rm -rf $(BUILD_DIR)
+	rm -rf $(COVERAGE_DIR)
 
-.PHONY: all clean docs test
+$(docs_dir): $(SOURCE_FILES)
+	rm -rf $(docs_dir)
+	$(GET_DEPENDENCIES_WITH)
+	$(PONYC) --docs-public --pass=docs --output build $(SRC_DIR)
+
+docs: $(docs_dir)
+
+TAGS:
+	ctags --recurse=yes $(SRC_DIR)
+
+coverage: $(coverage_binary)
+	kcov --include-pattern="/$(SRC_DIR)/" --exclude-pattern="/test/,_test.pony" $(COVERAGE_DIR) $(coverage_binary)
+
+$(coverage_binary): $(SOURCE_FILES) | $(COVERAGE_DIR)
+	$(GET_DEPENDENCIES_WITH)
+	$(PONYC) --debug -o $(COVERAGE_DIR) $(SRC_DIR)
+
+all: test
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+$(COVERAGE_DIR):
+	mkdir -p $(COVERAGE_DIR)
+
+.PHONY: all build-examples clean docs TAGS test coverage

--- a/examples/simple-example/simple-example.pony
+++ b/examples/simple-example/simple-example.pony
@@ -1,0 +1,7 @@
+// in your code this `use` statement would be:
+// use "templates"
+use "../../templates"
+
+actor Main
+  new create(env: Env) =>
+    env.out.print("we need at least 1 example. this one does nothing yet. want to contribute one?")


### PR DESCRIPTION
I left a `coverage` target that was present in the old Makefile. I don't have `kcov` installed and it doesn't seem to be well supported in macOS, so I wasn't able to test that it works. 

I don't think this should block the PR, but @Trundle do you think that you could verify that coverage still works for you?

Fixes #4 