### PR TITLE
Fix breakage workflow dispatch event type

### DIFF
--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -2,7 +2,7 @@ name: Test against ponyc nightly
 
 on:
   repository_dispatch:
-    types: [shared-docker-linux-builders-updated]
+    types: [shared-docker-builders-updated]
 
 permissions:
   packages: read


### PR DESCRIPTION
The breakage workflow listens for `shared-docker-linux-builders-updated` but shared-docker dispatches `shared-docker-builders-updated`. The old event type name is never sent, so this workflow has been dead — it never fires when ponyc Docker images are rebuilt.