### PR TITLE
Add else and elseif branches to if blocks

### DIFF
--- a/.release-notes/add-else-elseif.md
+++ b/.release-notes/add-else-elseif.md
@@ -1,0 +1,12 @@
+## Add else and elseif branches to if blocks
+
+`if` blocks now support `else` and `elseif` branches, so you no longer need to duplicate content with negated conditions.
+
+```pony
+let t = Template.parse(
+  "{{ if admin }}admin panel" +
+  "{{ elseif member }}member area" +
+  "{{ else }}public page{{ end }}")?
+```
+
+`elseif` chains can be as long as needed. A final `else` branch is optional and renders when no condition matches.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,15 @@
+# Examples
+
+Each subdirectory is a self-contained Pony program demonstrating a different part of the templates library. Ordered from simplest to most involved.
+
+## [simple-example](simple-example/)
+
+Parses a template with a single placeholder, binds a value, and renders the result. Demonstrates the core workflow: `Template.parse()`, `TemplateValues`, and `Template.render()`. Start here if you're new to the library.
+
+## [conditionals-example](conditionals-example/)
+
+Shows how to use `if`/`else` and `if`/`elseif`/`else` blocks to conditionally include content based on whether values are present. Demonstrates simple two-branch conditionals and chained multi-branch selection.
+
+## [functions-example](functions-example/)
+
+Registers a custom function via `TemplateContext` and calls it from within a template inside a `for` loop. Demonstrates how to extend templates with user-defined transformations.

--- a/examples/conditionals-example/conditionals-example.pony
+++ b/examples/conditionals-example/conditionals-example.pony
@@ -1,0 +1,50 @@
+// This example demonstrates if/else and if/elseif/else conditional blocks
+
+// In your code this `use` statement would be:
+// use "templates"
+use "../../templates"
+
+actor Main
+  new create(env: Env) =>
+    // Simple if/else: show different text based on whether a value exists
+    let greeting =
+      try
+        Template.parse(
+          "{{ if name }}Hello {{ name }}!{{ else }}Hello stranger!{{ end }}")?
+      else
+        env.err.print("Could not parse template :(")
+        env.exitcode(1)
+        return
+      end
+
+    // With a name → "Hello Alice!"
+    let with_name = TemplateValues
+    with_name("name") = "Alice"
+    try env.out.print(greeting.render(with_name)?) end
+
+    // Without a name → "Hello stranger!"
+    try env.out.print(greeting.render(TemplateValues)?) end
+
+    // Chained elseif: pick the first matching branch
+    let role_msg =
+      try
+        Template.parse(
+          "{{ if admin }}admin panel" +
+          "{{ elseif member }}member area" +
+          "{{ else }}public page{{ end }}")?
+      else
+        env.err.print("Could not parse template :(")
+        env.exitcode(1)
+        return
+      end
+
+    let admin_values = TemplateValues
+    admin_values("admin") = "yes"
+    try env.out.print(role_msg.render(admin_values)?) end  // "admin panel"
+
+    let member_values = TemplateValues
+    member_values("member") = "yes"
+    try env.out.print(role_msg.render(member_values)?) end  // "member area"
+
+    // No flags set → "public page"
+    try env.out.print(role_msg.render(TemplateValues)?) end

--- a/templates/_test.pony
+++ b/templates/_test.pony
@@ -32,6 +32,7 @@ actor \nodoc\ Main is TestList
     test(Property1UnitTest[String](_PropValidLoopParsesToLoopNode))
     test(Property1UnitTest[String](_PropValidIfParsesToIfNode))
     test(Property1UnitTest[String](_PropValidIfNotEmptyParsesToIfNotEmptyNode))
+    test(Property1UnitTest[String](_PropValidElseIfParsesToElseIfNode))
     test(Property1UnitTest[box->String](_PropInvalidStmtErrors))
     test(_TestParserNodeFields)
     test(_TestParserKeywordAmbiguity)
@@ -42,6 +43,7 @@ actor \nodoc\ Main is TestList
     test(_TestParseErrorUnknownFunction)
     test(_TestParseErrorMalformedStmt)
     test(_TestParseIncompleteDelimiters)
+    test(_TestParseErrorElseElseIf)
 
     // Template render tests (Step 6)
     test(Property1UnitTest[String](_PropLiteralIdentity))
@@ -53,6 +55,14 @@ actor \nodoc\ Main is TestList
     test(_TestRenderIfNotEmptyWithLoop)
     test(_TestRenderAdjacentPlaceholders)
     test(_TestRenderLoopVariableShadowing)
+
+    // Else/elseif render tests
+    test(_TestRenderIfElse)
+    test(_TestRenderIfElseIf)
+    test(_TestRenderIfElseIfElse)
+    test(_TestRenderMultipleElseIfs)
+    test(_TestRenderIfElseInsideLoop)
+    test(_TestRenderNestedIfElse)
 
     // Function call tests (Step 7)
     test(_TestCallWithNestedProp)
@@ -80,6 +90,7 @@ primitive \nodoc\ _Generators
     filtered to exclude names that parse as keywords:
     - Names starting with "end" (parse as _EndNode or error)
     - Names starting with "if" + alpha/underscore (parse as _IfNode)
+    - Names starting with "else" (parse as _ElseNode, _ElseIfNode, or error)
     """
     let first = _alpha_chars()
     let rest = _alnum_chars()
@@ -99,6 +110,9 @@ primitive \nodoc\ _Generators
       .filter({(s: String): (String^, Bool) =>
         // Reject names starting with "end"
         if s.at("end", 0) then return (consume s, false) end
+        // Reject names starting with "else" (parses as _ElseNode or
+        // _ElseIfNode)
+        if s.at("else", 0) then return (consume s, false) end
         // Reject names starting with "if" + alpha/underscore
         if (s.size() >= 3) and s.at("if", 0) then
           try
@@ -158,6 +172,12 @@ primitive \nodoc\ _Generators
     Generates `ifnotempty prop` — an ifnotempty statement.
     """
     valid_prop_stmt().map[String]({(prop) => "ifnotempty " + prop })
+
+  fun valid_elseif_stmt(): Generator[String] =>
+    """
+    Generates `elseif prop` — an elseif statement.
+    """
+    valid_prop_stmt().map[String]({(prop) => "elseif " + prop })
 
   fun invalid_stmt(): Generator[box->String] =>
     """
@@ -462,6 +482,16 @@ class \nodoc\ iso _PropValidIfNotEmptyParsesToIfNotEmptyNode
     _StmtParser.parse(stmt)? as _IfNotEmptyNode
 
 
+class \nodoc\ iso _PropValidElseIfParsesToElseIfNode is Property1[String]
+  fun name(): String => "Parser: valid elseif parses to _ElseIfNode"
+
+  fun gen(): Generator[String] =>
+    _Generators.valid_elseif_stmt()
+
+  fun ref property(stmt: String, h: PropertyHelper) ? =>
+    _StmtParser.parse(stmt)? as _ElseIfNode
+
+
 class \nodoc\ iso _PropInvalidStmtErrors is Property1[box->String]
   fun name(): String => "Parser: invalid statements error"
 
@@ -546,6 +576,29 @@ class \nodoc\ iso _TestParserNodeFields is UnitTest
     else h.fail("expected _PropNode for stripped input"); error
     end
 
+    // "else" → _ElseNode
+    match _StmtParser.parse("else")?
+    | _ElseNode => None
+    else h.fail("expected _ElseNode"); error
+    end
+
+    // "elseif active" → _ElseIfNode(value=_PropNode("active", []))
+    match _StmtParser.parse("elseif active")?
+    | let ei: _ElseIfNode =>
+      h.assert_eq[String]("active", ei.value.name)
+      h.assert_eq[USize](0, ei.value.props.size())
+    else h.fail("expected _ElseIfNode"); error
+    end
+
+    // "elseif a.b" → _ElseIfNode with dotted prop
+    match _StmtParser.parse("elseif a.b")?
+    | let ei: _ElseIfNode =>
+      h.assert_eq[String]("a", ei.value.name)
+      h.assert_eq[USize](1, ei.value.props.size())
+      h.assert_eq[String]("b", ei.value.props(0)?)
+    else h.fail("expected _ElseIfNode with dotted prop"); error
+    end
+
 
 class \nodoc\ iso _TestParserKeywordAmbiguity is UnitTest
   fun name(): String => "Parser: keyword ambiguity behavior"
@@ -593,6 +646,18 @@ class \nodoc\ iso _TestParserKeywordAmbiguity is UnitTest
       else error
       end
     })
+
+    // "elseiffoo" → _ElseIfNode(value=_PropNode("foo"))
+    h.assert_no_error({() ? =>
+      match _StmtParser.parse("elseiffoo")?
+      | let ei: _ElseIfNode =>
+        if ei.value.name != "foo" then error end
+      else error
+      end
+    })
+
+    // "elsewhere" → error (else matches, "where" is leftover → pos < expected)
+    h.assert_error({() ? => _StmtParser.parse("elsewhere")? })
 
 
 // ---------------------------------------------------------------------------
@@ -650,6 +715,52 @@ class \nodoc\ iso _TestParseIncompleteDelimiters is UnitTest
     let template = Template.parse("Hello {{ name")?
     h.assert_eq[String](
       "Hello {{ name", template.render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestParseErrorElseElseIf is UnitTest
+  fun name(): String => "Template parse error: else/elseif misuse"
+
+  fun apply(h: TestHelper) =>
+    // else at top level
+    h.assert_error({() ? => Template.parse("{{ else }}")? })
+
+    // elseif at top level
+    h.assert_error({() ? => Template.parse("{{ elseif x }}")? })
+
+    // Double else
+    h.assert_error({() ? =>
+      Template.parse("{{ if a }}A{{ else }}B{{ else }}C{{ end }}")?
+    })
+
+    // elseif after else
+    h.assert_error({() ? =>
+      Template.parse("{{ if a }}A{{ else }}B{{ elseif c }}C{{ end }}")?
+    })
+
+    // else in a for loop
+    h.assert_error({() ? =>
+      Template.parse("{{ for x in xs }}{{ else }}{{ end }}")?
+    })
+
+    // elseif in a for loop
+    h.assert_error({() ? =>
+      Template.parse("{{ for x in xs }}{{ elseif y }}{{ end }}")?
+    })
+
+    // else in an ifnotempty block
+    h.assert_error({() ? =>
+      Template.parse("{{ ifnotempty seq }}{{ else }}{{ end }}")?
+    })
+
+    // elseif in an ifnotempty block
+    h.assert_error({() ? =>
+      Template.parse("{{ ifnotempty seq }}{{ elseif y }}{{ end }}")?
+    })
+
+    // Unclosed elseif chain
+    h.assert_error({() ? =>
+      Template.parse("{{ if a }}A{{ elseif b }}B")?
+    })
 
 
 // ---------------------------------------------------------------------------
@@ -799,6 +910,146 @@ class \nodoc\ iso _TestRenderLoopVariableShadowing is UnitTest
       "{{ x }}-{{ for x in items }}{{ x }}{{ end }}-{{ x }}")?
     h.assert_eq[String](
       "outer-inner1inner2-outer", template.render(values)?)
+
+
+class \nodoc\ iso _TestRenderIfElse is UnitTest
+  fun name(): String => "Render: if/else branches"
+
+  fun apply(h: TestHelper)? =>
+    let template = Template.parse("{{ if flag }}yes{{ else }}no{{ end }}")?
+
+    // Value present → if body
+    let values = TemplateValues
+    values("flag") = "true"
+    h.assert_eq[String]("yes", template.render(values)?)
+
+    // Value absent → else body
+    h.assert_eq[String]("no", template.render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestRenderIfElseIf is UnitTest
+  fun name(): String => "Render: if/elseif branches"
+
+  fun apply(h: TestHelper)? =>
+    let template = Template.parse(
+      "{{ if a }}A{{ elseif b }}B{{ end }}")?
+
+    // First matches
+    let v1 = TemplateValues
+    v1("a") = "yes"
+    h.assert_eq[String]("A", template.render(v1)?)
+
+    // Second matches
+    let v2 = TemplateValues
+    v2("b") = "yes"
+    h.assert_eq[String]("B", template.render(v2)?)
+
+    // Neither matches → empty
+    h.assert_eq[String]("", template.render(TemplateValues)?)
+
+    // Both match → first wins
+    let v3 = TemplateValues
+    v3("a") = "yes"
+    v3("b") = "yes"
+    h.assert_eq[String]("A", template.render(v3)?)
+
+
+class \nodoc\ iso _TestRenderIfElseIfElse is UnitTest
+  fun name(): String => "Render: if/elseif/else branches"
+
+  fun apply(h: TestHelper)? =>
+    let template = Template.parse(
+      "{{ if a }}A{{ elseif b }}B{{ else }}C{{ end }}")?
+
+    // First matches
+    let v1 = TemplateValues
+    v1("a") = "yes"
+    h.assert_eq[String]("A", template.render(v1)?)
+
+    // Second matches
+    let v2 = TemplateValues
+    v2("b") = "yes"
+    h.assert_eq[String]("B", template.render(v2)?)
+
+    // None match → else body
+    h.assert_eq[String]("C", template.render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestRenderMultipleElseIfs is UnitTest
+  fun name(): String => "Render: multiple elseif chain"
+
+  fun apply(h: TestHelper)? =>
+    let template = Template.parse(
+      "{{ if a }}A{{ elseif b }}B{{ elseif c }}C{{ else }}D{{ end }}")?
+
+    let v1 = TemplateValues
+    v1("a") = "yes"
+    h.assert_eq[String]("A", template.render(v1)?)
+
+    let v2 = TemplateValues
+    v2("b") = "yes"
+    h.assert_eq[String]("B", template.render(v2)?)
+
+    let v3 = TemplateValues
+    v3("c") = "yes"
+    h.assert_eq[String]("C", template.render(v3)?)
+
+    h.assert_eq[String]("D", template.render(TemplateValues)?)
+
+    // Multiple match → first wins
+    let v5 = TemplateValues
+    v5("b") = "yes"
+    v5("c") = "yes"
+    h.assert_eq[String]("B", template.render(v5)?)
+
+
+class \nodoc\ iso _TestRenderIfElseInsideLoop is UnitTest
+  fun name(): String => "Render: if/else inside for loop"
+
+  fun apply(h: TestHelper)? =>
+    let values = TemplateValues
+
+    let item1_props = Map[String, TemplateValue]
+    item1_props("active") = TemplateValue("yes")
+    let item2_props = Map[String, TemplateValue]
+
+    values("items") = TemplateValue(
+      [TemplateValue("A", item1_props)
+       TemplateValue("B", item2_props)])
+
+    let template = Template.parse(
+      "{{ for x in items }}" +
+      "{{ if x.active }}+{{ else }}-{{ end }}" +
+      "{{ end }}")?
+    h.assert_eq[String]("+-", template.render(values)?)
+
+
+class \nodoc\ iso _TestRenderNestedIfElse is UnitTest
+  fun name(): String => "Render: nested if/else blocks"
+
+  fun apply(h: TestHelper)? =>
+    let template = Template.parse(
+      "{{ if a }}{{ if b }}AB{{ else }}A{{ end }}" +
+      "{{ else }}{{ if b }}B{{ else }}none{{ end }}{{ end }}")?
+
+    // Both present
+    let v1 = TemplateValues
+    v1("a") = "yes"
+    v1("b") = "yes"
+    h.assert_eq[String]("AB", template.render(v1)?)
+
+    // Only a
+    let v2 = TemplateValues
+    v2("a") = "yes"
+    h.assert_eq[String]("A", template.render(v2)?)
+
+    // Only b
+    let v3 = TemplateValues
+    v3("b") = "yes"
+    h.assert_eq[String]("B", template.render(v3)?)
+
+    // Neither
+    h.assert_eq[String]("none", template.render(TemplateValues)?)
 
 
 // ---------------------------------------------------------------------------

--- a/templates/parser.pony
+++ b/templates/parser.pony
@@ -8,8 +8,17 @@ primitive _TLoop is Label fun text(): String => "Loop"
 primitive _TEnd is Label fun text(): String => "End"
 primitive _TIf is Label fun text(): String => "If"
 primitive _TIfNotEmpty is Label fun text(): String => "IfNotEmpty"
+primitive _TElse is Label fun text(): String => "Else"
+primitive _TElseIf is Label fun text(): String => "ElseIf"
 
 primitive _EndNode
+primitive _ElseNode
+
+class box _ElseIfNode
+  let value: _PropNode
+
+  new box create(value': _PropNode) =>
+    value = value'
 
 class box _PropNode
   let name: String
@@ -47,7 +56,9 @@ class box _LoopNode
     target = target'
     source = source'
 
-type _StmtNode is (_EndNode | _PropNode | _CallNode | _IfNode | _IfNotEmptyNode | _LoopNode)
+type _StmtNode is
+  ( _EndNode | _ElseNode | _ElseIfNode
+  | _PropNode | _CallNode | _IfNode | _IfNotEmptyNode | _LoopNode )
 
 primitive _StmtParser
   fun _parser(): Parser val =>
@@ -66,9 +77,11 @@ primitive _StmtParser
       let end' = L("end").term(_TEnd)
       let loop = (L("for") * name * L("in") * prop).node(_TLoop).hide(whitespace)
       let ifnotempty = (L("ifnotempty") * prop).node(_TIfNotEmpty).hide(whitespace)
+      let else_if = (L("elseif") * prop).node(_TElseIf).hide(whitespace)
+      let else' = L("else").term(_TElse)
       let if' = (L("if") * prop).node(_TIf).hide(whitespace)
 
-      let stmt = ifnotempty / if' / loop / end' / expr
+      let stmt = ifnotempty / if' / loop / else_if / else' / end' / expr
       stmt
     end
 
@@ -83,6 +96,8 @@ primitive _StmtParser
       match ast.label()
       | let if': _TIf => _parse_if(ast as AST)?
       | let ifnotempty: _TIfNotEmpty => _parse_ifnotempty(ast as AST)?
+      | let _: _TElse => _ElseNode
+      | let _: _TElseIf => _parse_elseif(ast as AST)?
       | let _: _TEnd => _EndNode
       | let call: _TCall => _parse_call(ast as AST)?
       | let loop: _TLoop => _parse_loop(ast as AST)?
@@ -102,6 +117,9 @@ primitive _StmtParser
 
   fun _parse_ifnotempty(ast: AST): _IfNotEmptyNode? =>
     _IfNotEmptyNode(_parse_prop(ast.children(1)? as AST)?)
+
+  fun _parse_elseif(ast: AST): _ElseIfNode? =>
+    _ElseIfNode(_parse_prop(ast.children(1)? as AST)?)
 
   fun _parse_loop(ast: AST): _LoopNode? =>
     let target = (ast.children(1)? as Token).string()

--- a/templates/template.pony
+++ b/templates/template.pony
@@ -1,5 +1,16 @@
 """
 A simple text-based template engine.
+
+Templates are strings containing literal text interspersed with `{{ ... }}`
+blocks. Supported block types:
+
+* **Variable substitution**: `{{ name }}` or `{{ obj.prop }}`
+* **Conditionals**: `{{ if flag }}...{{ end }}`, with optional
+  `{{ else }}` and `{{ elseif other }}` branches
+* **Existence check**: `{{ ifnotempty seq }}...{{ end }}`
+* **Loops**: `{{ for item in items }}...{{ end }}`
+* **Function calls**: `{{ fn(arg) }}` using functions registered via
+  `TemplateContext`
 """
 
 use "collections"
@@ -20,10 +31,29 @@ class _Call
 class _If
   let value: _PropNode
   let body: Array[_Part] box
+  let else_body: (Array[_Part] box | None)
 
-  new box create(value': _PropNode, body': Array[_Part] box) =>
+  new box create(
+    value': _PropNode,
+    body': Array[_Part] box,
+    else_body': (Array[_Part] box | None) = None
+  ) =>
     value = value'
     body = body'
+    else_body = else_body'
+
+class box _IfElse
+  """
+  Marker on the open-block stack indicating an `if` that has transitioned to
+  its `else` branch. Stores the original condition and if-body so they can be
+  assembled into the final `_If` node when `end` is encountered.
+  """
+  let value: _PropNode
+  let if_body: Array[_Part] box
+
+  new box create(value': _PropNode, if_body': Array[_Part] box) =>
+    value = value'
+    if_body = if_body'
 
 class _IfNotEmpty
   let value: _PropNode
@@ -151,7 +181,7 @@ class val Template
   fun tag _parse(source: String, ctx: TemplateContext val): Array[_Part] box? =>
     var parts: Array[_Part] = []
     var current_parts = parts
-    var open: Array[((_IfNode | _IfNotEmptyNode | _LoopNode), Array[_Part])] = []
+    var open: Array[((_IfNode | _IfNotEmptyNode | _LoopNode | _IfElse), Array[_Part], Bool)] = []
     var prev_end: ISize = 0
     while prev_end < source.size().isize() do
       let start_pos =
@@ -168,18 +198,21 @@ class val Template
       let stmt_source: String = source.substring(start_pos + 2, end_pos)
       match _StmtParser.parse(stmt_source)?
       | _EndNode => current_parts = _parse_end(open, parts)?
+      | _ElseNode => current_parts = _parse_else(open)?
+      | let else_if: _ElseIfNode =>
+        current_parts = _parse_elseif_stmt(open, else_if)?
       | let prop: _PropNode => current_parts.push(prop)
       | let call: _CallNode =>
         current_parts.push(_Call(ctx.functions(call.name)?, call.arg))
       | let if': _IfNode =>
         current_parts = Array[_Part]
-        open.push((if', current_parts))
+        open.push((if', current_parts, false))
       | let ifnotempty: _IfNotEmptyNode =>
         current_parts = Array[_Part]
-        open.push((ifnotempty, current_parts))
+        open.push((ifnotempty, current_parts, false))
       | let loop: _LoopNode =>
         current_parts = Array[_Part]
-        open.push((loop, current_parts))
+        open.push((loop, current_parts, false))
       end
 
       prev_end = end_pos + 2
@@ -194,26 +227,72 @@ class val Template
     consume parts
 
   fun tag _parse_end(
-    open: Array[((_IfNode | _IfNotEmptyNode | _LoopNode), Array[_Part])],
+    open: Array[((_IfNode | _IfNotEmptyNode | _LoopNode | _IfElse), Array[_Part], Bool)],
     parts: Array[_Part]
   ): Array[_Part]? =>
-    (let stmt, let body) = open.pop()?
+    (let stmt, let body, _) = open.pop()?
+
+    let node: _Part =
+      match stmt
+      | let if': _IfNode => _If(if'.value, body)
+      | let ie: _IfElse => _If(ie.value, ie.if_body, body)
+      | let ifnotempty: _IfNotEmptyNode => _IfNotEmpty(ifnotempty.value, body)
+      | let loop: _LoopNode => _Loop(loop.target, loop.source, body)
+      end
+
+    // Auto-close elseif chain entries
+    var current_node: _Part = node
+    while open.size() > 0 do
+      if open(open.size() - 1)?._3 then
+        (let outer_stmt, let outer_body, _) = open.pop()?
+        match outer_stmt
+        | let ie: _IfElse =>
+          outer_body.push(current_node)
+          current_node = _If(ie.value, ie.if_body, outer_body)
+        else
+          error // auto_close should only be set on _IfElse entries
+        end
+      else
+        break
+      end
+    end
 
     let next_current =
       if open.size() == 0 then parts
       else open(open.size() - 1)?._2
       end
 
+    next_current.push(current_node)
+    next_current
+
+  fun tag _parse_else(
+    open: Array[((_IfNode | _IfNotEmptyNode | _LoopNode | _IfElse), Array[_Part], Bool)]
+  ): Array[_Part]? =>
+    (let stmt, let if_body, _) = open.pop()?
     match stmt
     | let if': _IfNode =>
-      next_current.push(_If(if'.value, body))
-    | let ifnotempty: _IfNotEmptyNode =>
-      next_current.push(_IfNotEmpty(ifnotempty.value, body))
-    | let loop: _LoopNode =>
-      next_current.push(_Loop(loop.target, loop.source, body))
+      let else_body = Array[_Part]
+      open.push((_IfElse(if'.value, if_body), else_body, false))
+      else_body
+    else
+      error // else only valid inside an if block
     end
 
-    next_current
+  fun tag _parse_elseif_stmt(
+    open: Array[((_IfNode | _IfNotEmptyNode | _LoopNode | _IfElse), Array[_Part], Bool)],
+    else_if: _ElseIfNode
+  ): Array[_Part]? =>
+    (let stmt, let if_body, _) = open.pop()?
+    match stmt
+    | let if': _IfNode =>
+      let else_body = Array[_Part]
+      open.push((_IfElse(if'.value, if_body), else_body, true))
+      let else_if_body = Array[_Part]
+      open.push((_IfNode(else_if.value), else_if_body, false))
+      else_if_body
+    else
+      error // elseif only valid inside an if block
+    end
 
   fun render(values: TemplateValues box): String? =>
     """
@@ -237,6 +316,11 @@ class val Template
         try
           values._lookup(if'.value)?
           result = result + _render_parts(if'.body, values)?
+        else
+          match if'.else_body
+          | let eb: Array[_Part] box =>
+            result = result + _render_parts(eb, values)?
+          end
         end
       | let ifnotempty: _IfNotEmpty box =>
         if values._lookup(ifnotempty.value)?.values().has_next() then


### PR DESCRIPTION
The `if` block had no `else` branch, which forced users to duplicate content with negated conditions for the common "if this, otherwise that" pattern. This adds `else` and `elseif` support:

```
{{ if flag }}yes{{ else }}no{{ end }}
{{ if a }}A{{ elseif b }}B{{ else }}C{{ end }}
```

`elseif` chains are desugared during parsing into nested `_If` nodes inside else bodies, so the AST stays simple: `_If` just gains an optional `else_body` field, and rendering is recursive. The parser rejects misuse at parse time (else/elseif inside loops or ifnotempty, double else, elseif after else).

`ifnotempty` intentionally does not get `else` support in this PR to keep scope narrow.

Design: #38