### PR TITLE
Add `ifnot` negated conditional blocks

### DIFF
--- a/.release-notes/add-ifnot-blocks.md
+++ b/.release-notes/add-ifnot-blocks.md
@@ -1,0 +1,15 @@
+## Add `ifnot` negated conditional blocks
+
+`ifnot` renders its body when a variable is absent — the logical inverse of `if`. This lets you write the "missing" case as the primary branch instead of requiring an `if`/`else` just to get at the `else`.
+
+```pony
+let t = Template.parse(
+  "{{ ifnot name }}Anonymous{{ end }}")?
+```
+
+Like `if`, `ifnot` supports `else` and `elseif` branches:
+
+```pony
+let t = Template.parse(
+  "{{ ifnot name }}Anonymous{{ else }}{{ name }}{{ end }}")?
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ Parses a template with a single placeholder, binds a value, and renders the resu
 
 ## [conditionals-example](conditionals-example/)
 
-Shows how to use `if`/`else` and `if`/`elseif`/`else` blocks to conditionally include content based on whether values are present. Demonstrates simple two-branch conditionals and chained multi-branch selection.
+Shows how to use `if`/`else`, `if`/`elseif`/`else`, and `ifnot` blocks to conditionally include content based on whether values are present or absent. Demonstrates simple two-branch conditionals, chained multi-branch selection, and negated conditionals for the absent-variable case.
 
 ## [functions-example](functions-example/)
 

--- a/examples/conditionals-example/conditionals-example.pony
+++ b/examples/conditionals-example/conditionals-example.pony
@@ -1,4 +1,5 @@
-// This example demonstrates if/else and if/elseif/else conditional blocks
+// This example demonstrates if/else, if/elseif/else, and ifnot conditional
+// blocks
 
 // In your code this `use` statement would be:
 // use "templates"
@@ -48,3 +49,37 @@ actor Main
 
     // No flags set → "public page"
     try env.out.print(role_msg.render(TemplateValues)?) end
+
+    // Negated conditional: render content when a variable is absent
+    let anon =
+      try
+        Template.parse(
+          "{{ ifnot name }}Anonymous{{ end }}")?
+      else
+        env.err.print("Could not parse template :(")
+        env.exitcode(1)
+        return
+      end
+
+    // Without a name → "Anonymous"
+    try env.out.print(anon.render(TemplateValues)?) end
+
+    // With a name → "" (empty, body not rendered)
+    try env.out.print(anon.render(with_name)?) end
+
+    // ifnot with else: different content based on absence vs presence
+    let display_name =
+      try
+        Template.parse(
+          "{{ ifnot name }}Anonymous{{ else }}{{ name }}{{ end }}")?
+      else
+        env.err.print("Could not parse template :(")
+        env.exitcode(1)
+        return
+      end
+
+    // Without a name → "Anonymous"
+    try env.out.print(display_name.render(TemplateValues)?) end
+
+    // With a name → "Alice"
+    try env.out.print(display_name.render(with_name)?) end

--- a/templates/_test.pony
+++ b/templates/_test.pony
@@ -31,6 +31,7 @@ actor \nodoc\ Main is TestList
     test(Property1UnitTest[String](_PropValidCallParsesToCallNode))
     test(Property1UnitTest[String](_PropValidLoopParsesToLoopNode))
     test(Property1UnitTest[String](_PropValidIfParsesToIfNode))
+    test(Property1UnitTest[String](_PropValidIfNotParsesToIfNotNode))
     test(Property1UnitTest[String](_PropValidIfNotEmptyParsesToIfNotEmptyNode))
     test(Property1UnitTest[String](_PropValidElseIfParsesToElseIfNode))
     test(Property1UnitTest[box->String](_PropInvalidStmtErrors))
@@ -55,6 +56,14 @@ actor \nodoc\ Main is TestList
     test(_TestRenderIfNotEmptyWithLoop)
     test(_TestRenderAdjacentPlaceholders)
     test(_TestRenderLoopVariableShadowing)
+
+    // ifnot render tests
+    test(_TestRenderIfNot)
+    test(_TestRenderIfNotElse)
+    test(_TestRenderIfNotElseIf)
+    test(_TestRenderIfNotElseIfElse)
+    test(_TestRenderIfNotInsideLoop)
+    test(_TestRenderNestedIfNotWithIf)
 
     // Else/elseif render tests
     test(_TestRenderIfElse)
@@ -89,7 +98,8 @@ primitive \nodoc\ _Generators
     Generates valid identifier names matching [a-zA-Z_][a-zA-Z0-9_]{0,19},
     filtered to exclude names that parse as keywords:
     - Names starting with "end" (parse as _EndNode or error)
-    - Names starting with "if" + alpha/underscore (parse as _IfNode)
+    - Names starting with "if" + alpha/underscore (parse as _IfNode or
+      _IfNotNode)
     - Names starting with "else" (parse as _ElseNode, _ElseIfNode, or error)
     """
     let first = _alpha_chars()
@@ -166,6 +176,12 @@ primitive \nodoc\ _Generators
     Generates `if prop` — an if statement.
     """
     valid_prop_stmt().map[String]({(prop) => "if " + prop })
+
+  fun valid_ifnot_stmt(): Generator[String] =>
+    """
+    Generates `ifnot prop` — an ifnot statement.
+    """
+    valid_prop_stmt().map[String]({(prop) => "ifnot " + prop })
 
   fun valid_ifnotempty_stmt(): Generator[String] =>
     """
@@ -323,6 +339,8 @@ class \nodoc\ iso _StmtParserTest is UnitTest
     h.assert_no_error(
       {()? => _StmtParser.parse("foo(spam.eggs)")? as _CallNode })
     h.assert_no_error(
+      {()? => _StmtParser.parse("ifnot spam")? as _IfNotNode })
+    h.assert_no_error(
       {()? => _StmtParser.parse("ifnotempty spam")? as _IfNotEmptyNode })
 
 
@@ -470,6 +488,16 @@ class \nodoc\ iso _PropValidIfParsesToIfNode is Property1[String]
     _StmtParser.parse(stmt)? as _IfNode
 
 
+class \nodoc\ iso _PropValidIfNotParsesToIfNotNode is Property1[String]
+  fun name(): String => "Parser: valid ifnot parses to _IfNotNode"
+
+  fun gen(): Generator[String] =>
+    _Generators.valid_ifnot_stmt()
+
+  fun ref property(stmt: String, h: PropertyHelper) ? =>
+    _StmtParser.parse(stmt)? as _IfNotNode
+
+
 class \nodoc\ iso _PropValidIfNotEmptyParsesToIfNotEmptyNode
   is Property1[String]
   fun name(): String =>
@@ -560,6 +588,14 @@ class \nodoc\ iso _TestParserNodeFields is UnitTest
     else h.fail("expected _IfNode"); error
     end
 
+    // "ifnot active" → _IfNotNode(value=_PropNode("active", []))
+    match _StmtParser.parse("ifnot active")?
+    | let i: _IfNotNode =>
+      h.assert_eq[String]("active", i.value.name)
+      h.assert_eq[USize](0, i.value.props.size())
+    else h.fail("expected _IfNotNode"); error
+    end
+
     // "ifnotempty seq" → _IfNotEmptyNode(value=_PropNode("seq", []))
     match _StmtParser.parse("ifnotempty seq")?
     | let i: _IfNotEmptyNode =>
@@ -628,6 +664,15 @@ class \nodoc\ iso _TestParserKeywordAmbiguity is UnitTest
       end
     })
 
+    // "ifnotx" → _IfNotNode(value=_PropNode("x"))
+    h.assert_no_error({() ? =>
+      match _StmtParser.parse("ifnotx")?
+      | let i: _IfNotNode =>
+        if i.value.name != "x" then error end
+      else error
+      end
+    })
+
     // "for" → _PropNode(name="for") (keyword rule fails, falls through)
     h.assert_no_error({() ? =>
       _StmtParser.parse("for")? as _PropNode
@@ -638,11 +683,21 @@ class \nodoc\ iso _TestParserKeywordAmbiguity is UnitTest
       _StmtParser.parse("if")? as _PropNode
     })
 
-    // "ifnotempty" → _IfNode(value=_PropNode("notempty"))
+    // "ifnot" → _IfNode(value=_PropNode("not"))
+    h.assert_no_error({() ? =>
+      match _StmtParser.parse("ifnot")?
+      | let i: _IfNode =>
+        if i.value.name != "not" then error end
+      else error
+      end
+    })
+
+    // "ifnotempty" → _IfNotNode(value=_PropNode("empty"))
+    // (ifnot rule matches before if rule, consuming "ifnot" + "empty")
     h.assert_no_error({() ? =>
       match _StmtParser.parse("ifnotempty")?
-      | let i: _IfNode =>
-        if i.value.name != "notempty" then error end
+      | let i: _IfNotNode =>
+        if i.value.name != "empty" then error end
       else error
       end
     })
@@ -673,6 +728,9 @@ class \nodoc\ iso _TestParseErrorUnclosedBlock is UnitTest
     })
     h.assert_error({() ? =>
       Template.parse("{{ if flag }}body")?
+    })
+    h.assert_error({() ? =>
+      Template.parse("{{ ifnot flag }}body")?
     })
     h.assert_error({() ? =>
       Template.parse("{{ ifnotempty seq }}body")?
@@ -755,6 +813,18 @@ class \nodoc\ iso _TestParseErrorElseElseIf is UnitTest
     // elseif in an ifnotempty block
     h.assert_error({() ? =>
       Template.parse("{{ ifnotempty seq }}{{ elseif y }}{{ end }}")?
+    })
+
+    // Double else in ifnot
+    h.assert_error({() ? =>
+      Template.parse(
+        "{{ ifnot a }}A{{ else }}B{{ else }}C{{ end }}")?
+    })
+
+    // elseif after else in ifnot
+    h.assert_error({() ? =>
+      Template.parse(
+        "{{ ifnot a }}A{{ else }}B{{ elseif c }}C{{ end }}")?
     })
 
     // Unclosed elseif chain
@@ -1050,6 +1120,129 @@ class \nodoc\ iso _TestRenderNestedIfElse is UnitTest
 
     // Neither
     h.assert_eq[String]("none", template.render(TemplateValues)?)
+
+
+// ---------------------------------------------------------------------------
+// ifnot render tests
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _TestRenderIfNot is UnitTest
+  fun name(): String => "Render: ifnot renders when absent"
+
+  fun apply(h: TestHelper)? =>
+    let template = Template.parse(
+      "{{ ifnot name }}Anonymous{{ end }}")?
+
+    // Variable absent → body rendered
+    h.assert_eq[String]("Anonymous", template.render(TemplateValues)?)
+
+    // Variable present → empty
+    let values = TemplateValues
+    values("name") = "Alice"
+    h.assert_eq[String]("", template.render(values)?)
+
+
+class \nodoc\ iso _TestRenderIfNotElse is UnitTest
+  fun name(): String => "Render: ifnot/else branches"
+
+  fun apply(h: TestHelper)? =>
+    let template = Template.parse(
+      "{{ ifnot name }}Anonymous{{ else }}{{ name }}{{ end }}")?
+
+    // Variable absent → ifnot body
+    h.assert_eq[String]("Anonymous", template.render(TemplateValues)?)
+
+    // Variable present → else body
+    let values = TemplateValues
+    values("name") = "Alice"
+    h.assert_eq[String]("Alice", template.render(values)?)
+
+
+class \nodoc\ iso _TestRenderIfNotElseIf is UnitTest
+  fun name(): String => "Render: ifnot/elseif branches"
+
+  fun apply(h: TestHelper)? =>
+    let template = Template.parse(
+      "{{ ifnot a }}no-a{{ elseif b }}has-b{{ end }}")?
+
+    // a absent → ifnot body
+    h.assert_eq[String]("no-a", template.render(TemplateValues)?)
+
+    // a present, b present → elseif body
+    let v1 = TemplateValues
+    v1("a") = "yes"
+    v1("b") = "yes"
+    h.assert_eq[String]("has-b", template.render(v1)?)
+
+    // a present, b absent → empty
+    let v2 = TemplateValues
+    v2("a") = "yes"
+    h.assert_eq[String]("", template.render(v2)?)
+
+
+class \nodoc\ iso _TestRenderIfNotElseIfElse is UnitTest
+  fun name(): String => "Render: ifnot/elseif/else full chain"
+
+  fun apply(h: TestHelper)? =>
+    let template = Template.parse(
+      "{{ ifnot a }}no-a{{ elseif b }}has-b{{ else }}fallback{{ end }}")?
+
+    // a absent → ifnot body
+    h.assert_eq[String]("no-a", template.render(TemplateValues)?)
+
+    // a present, b present → elseif body
+    let v1 = TemplateValues
+    v1("a") = "yes"
+    v1("b") = "yes"
+    h.assert_eq[String]("has-b", template.render(v1)?)
+
+    // a present, b absent → else body
+    let v2 = TemplateValues
+    v2("a") = "yes"
+    h.assert_eq[String]("fallback", template.render(v2)?)
+
+
+class \nodoc\ iso _TestRenderIfNotInsideLoop is UnitTest
+  fun name(): String => "Render: ifnot nested inside for loop"
+
+  fun apply(h: TestHelper)? =>
+    let values = TemplateValues
+
+    let item1_props = Map[String, TemplateValue]
+    item1_props("label") = TemplateValue("tagged")
+    let item2_props = Map[String, TemplateValue]
+
+    values("items") = TemplateValue(
+      [TemplateValue("A", item1_props)
+       TemplateValue("B", item2_props)])
+
+    let template = Template.parse(
+      "{{ for x in items }}" +
+      "{{ ifnot x.label }}unlabeled{{ else }}{{ x.label }}{{ end }}," +
+      "{{ end }}")?
+    h.assert_eq[String]("tagged,unlabeled,", template.render(values)?)
+
+
+class \nodoc\ iso _TestRenderNestedIfNotWithIf is UnitTest
+  fun name(): String => "Render: if nested inside ifnot"
+
+  fun apply(h: TestHelper)? =>
+    let template = Template.parse(
+      "{{ ifnot a }}{{ if b }}B-no-A{{ else }}no-A-no-B{{ end }}" +
+      "{{ else }}has-A{{ end }}")?
+
+    // a absent, b present
+    let v1 = TemplateValues
+    v1("b") = "yes"
+    h.assert_eq[String]("B-no-A", template.render(v1)?)
+
+    // a absent, b absent
+    h.assert_eq[String]("no-A-no-B", template.render(TemplateValues)?)
+
+    // a present
+    let v2 = TemplateValues
+    v2("a") = "yes"
+    h.assert_eq[String]("has-A", template.render(v2)?)
 
 
 // ---------------------------------------------------------------------------

--- a/templates/parser.pony
+++ b/templates/parser.pony
@@ -7,6 +7,7 @@ primitive _TProp is Label fun text(): String => "Prop"
 primitive _TLoop is Label fun text(): String => "Loop"
 primitive _TEnd is Label fun text(): String => "End"
 primitive _TIf is Label fun text(): String => "If"
+primitive _TIfNot is Label fun text(): String => "IfNot"
 primitive _TIfNotEmpty is Label fun text(): String => "IfNotEmpty"
 primitive _TElse is Label fun text(): String => "Else"
 primitive _TElseIf is Label fun text(): String => "ElseIf"
@@ -42,6 +43,12 @@ class box _IfNode
   new box create(value': _PropNode) =>
     value = value'
 
+class box _IfNotNode
+  let value: _PropNode
+
+  new box create(value': _PropNode) =>
+    value = value'
+
 class box _IfNotEmptyNode
   let value: _PropNode
 
@@ -58,7 +65,8 @@ class box _LoopNode
 
 type _StmtNode is
   ( _EndNode | _ElseNode | _ElseIfNode
-  | _PropNode | _CallNode | _IfNode | _IfNotEmptyNode | _LoopNode )
+  | _PropNode | _CallNode | _IfNode | _IfNotNode | _IfNotEmptyNode
+  | _LoopNode )
 
 primitive _StmtParser
   fun _parser(): Parser val =>
@@ -77,11 +85,12 @@ primitive _StmtParser
       let end' = L("end").term(_TEnd)
       let loop = (L("for") * name * L("in") * prop).node(_TLoop).hide(whitespace)
       let ifnotempty = (L("ifnotempty") * prop).node(_TIfNotEmpty).hide(whitespace)
+      let ifnot = (L("ifnot") * prop).node(_TIfNot).hide(whitespace)
       let else_if = (L("elseif") * prop).node(_TElseIf).hide(whitespace)
       let else' = L("else").term(_TElse)
       let if' = (L("if") * prop).node(_TIf).hide(whitespace)
 
-      let stmt = ifnotempty / if' / loop / else_if / else' / end' / expr
+      let stmt = ifnotempty / ifnot / if' / loop / else_if / else' / end' / expr
       stmt
     end
 
@@ -95,6 +104,7 @@ primitive _StmtParser
     | let ast: ASTChild =>
       match ast.label()
       | let if': _TIf => _parse_if(ast as AST)?
+      | let ifnot: _TIfNot => _parse_ifnot(ast as AST)?
       | let ifnotempty: _TIfNotEmpty => _parse_ifnotempty(ast as AST)?
       | let _: _TElse => _ElseNode
       | let _: _TElseIf => _parse_elseif(ast as AST)?
@@ -114,6 +124,9 @@ primitive _StmtParser
 
   fun _parse_if(ast: AST): _IfNode? =>
     _IfNode(_parse_prop(ast.children(1)? as AST)?)
+
+  fun _parse_ifnot(ast: AST): _IfNotNode? =>
+    _IfNotNode(_parse_prop(ast.children(1)? as AST)?)
 
   fun _parse_ifnotempty(ast: AST): _IfNotEmptyNode? =>
     _IfNotEmptyNode(_parse_prop(ast.children(1)? as AST)?)

--- a/templates/template.pony
+++ b/templates/template.pony
@@ -7,6 +7,8 @@ blocks. Supported block types:
 * **Variable substitution**: `{{ name }}` or `{{ obj.prop }}`
 * **Conditionals**: `{{ if flag }}...{{ end }}`, with optional
   `{{ else }}` and `{{ elseif other }}` branches
+* **Negated conditionals**: `{{ ifnot flag }}...{{ end }}`, renders when
+  the variable is absent; supports `{{ else }}` and `{{ elseif }}`
 * **Existence check**: `{{ ifnotempty seq }}...{{ end }}`
 * **Loops**: `{{ for item in items }}...{{ end }}`
 * **Function calls**: `{{ fn(arg) }}` using functions registered via
@@ -44,16 +46,37 @@ class _If
 
 class box _IfElse
   """
-  Marker on the open-block stack indicating an `if` that has transitioned to
-  its `else` branch. Stores the original condition and if-body so they can be
-  assembled into the final `_If` node when `end` is encountered.
+  Marker on the open-block stack indicating an `if` or `ifnot` block that has
+  transitioned to its `else` branch. Stores the original condition and if-body
+  so they can be assembled into the final `_If` or `_IfNot` node when `end` is
+  encountered.
   """
   let value: _PropNode
   let if_body: Array[_Part] box
+  let negated: Bool
 
-  new box create(value': _PropNode, if_body': Array[_Part] box) =>
+  new box create(
+    value': _PropNode,
+    if_body': Array[_Part] box,
+    negated': Bool = false
+  ) =>
     value = value'
     if_body = if_body'
+    negated = negated'
+
+class _IfNot
+  let value: _PropNode
+  let body: Array[_Part] box
+  let else_body: (Array[_Part] box | None)
+
+  new box create(
+    value': _PropNode,
+    body': Array[_Part] box,
+    else_body': (Array[_Part] box | None) = None
+  ) =>
+    value = value'
+    body = body'
+    else_body = else_body'
 
 class _IfNotEmpty
   let value: _PropNode
@@ -73,7 +96,9 @@ class _Loop
     source = source'
     body = body'
 
-type _Part is ((_Literal, String) | _Call box | _PropNode | _If box | _IfNotEmpty box | _Loop box)
+type _Part is
+  ( (_Literal, String) | _Call box | _PropNode
+  | _If box | _IfNot box | _IfNotEmpty box | _Loop box )
 
 
 class box TemplateValue
@@ -181,7 +206,7 @@ class val Template
   fun tag _parse(source: String, ctx: TemplateContext val): Array[_Part] box? =>
     var parts: Array[_Part] = []
     var current_parts = parts
-    var open: Array[((_IfNode | _IfNotEmptyNode | _LoopNode | _IfElse), Array[_Part], Bool)] = []
+    var open: Array[((_IfNode | _IfNotNode | _IfNotEmptyNode | _LoopNode | _IfElse), Array[_Part], Bool)] = []
     var prev_end: ISize = 0
     while prev_end < source.size().isize() do
       let start_pos =
@@ -207,6 +232,9 @@ class val Template
       | let if': _IfNode =>
         current_parts = Array[_Part]
         open.push((if', current_parts, false))
+      | let ifnot: _IfNotNode =>
+        current_parts = Array[_Part]
+        open.push((ifnot, current_parts, false))
       | let ifnotempty: _IfNotEmptyNode =>
         current_parts = Array[_Part]
         open.push((ifnotempty, current_parts, false))
@@ -227,7 +255,7 @@ class val Template
     consume parts
 
   fun tag _parse_end(
-    open: Array[((_IfNode | _IfNotEmptyNode | _LoopNode | _IfElse), Array[_Part], Bool)],
+    open: Array[((_IfNode | _IfNotNode | _IfNotEmptyNode | _LoopNode | _IfElse), Array[_Part], Bool)],
     parts: Array[_Part]
   ): Array[_Part]? =>
     (let stmt, let body, _) = open.pop()?
@@ -235,7 +263,11 @@ class val Template
     let node: _Part =
       match stmt
       | let if': _IfNode => _If(if'.value, body)
-      | let ie: _IfElse => _If(ie.value, ie.if_body, body)
+      | let ifnot: _IfNotNode => _IfNot(ifnot.value, body)
+      | let ie: _IfElse =>
+        if ie.negated then _IfNot(ie.value, ie.if_body, body)
+        else _If(ie.value, ie.if_body, body)
+        end
       | let ifnotempty: _IfNotEmptyNode => _IfNotEmpty(ifnotempty.value, body)
       | let loop: _LoopNode => _Loop(loop.target, loop.source, body)
       end
@@ -248,7 +280,10 @@ class val Template
         match outer_stmt
         | let ie: _IfElse =>
           outer_body.push(current_node)
-          current_node = _If(ie.value, ie.if_body, outer_body)
+          current_node =
+            if ie.negated then _IfNot(ie.value, ie.if_body, outer_body)
+            else _If(ie.value, ie.if_body, outer_body)
+            end
         else
           error // auto_close should only be set on _IfElse entries
         end
@@ -266,7 +301,7 @@ class val Template
     next_current
 
   fun tag _parse_else(
-    open: Array[((_IfNode | _IfNotEmptyNode | _LoopNode | _IfElse), Array[_Part], Bool)]
+    open: Array[((_IfNode | _IfNotNode | _IfNotEmptyNode | _LoopNode | _IfElse), Array[_Part], Bool)]
   ): Array[_Part]? =>
     (let stmt, let if_body, _) = open.pop()?
     match stmt
@@ -274,12 +309,17 @@ class val Template
       let else_body = Array[_Part]
       open.push((_IfElse(if'.value, if_body), else_body, false))
       else_body
+    | let ifnot: _IfNotNode =>
+      let else_body = Array[_Part]
+      open.push(
+        (_IfElse(ifnot.value, if_body where negated' = true), else_body, false))
+      else_body
     else
-      error // else only valid inside an if block
+      error // else only valid inside an if or ifnot block
     end
 
   fun tag _parse_elseif_stmt(
-    open: Array[((_IfNode | _IfNotEmptyNode | _LoopNode | _IfElse), Array[_Part], Bool)],
+    open: Array[((_IfNode | _IfNotNode | _IfNotEmptyNode | _LoopNode | _IfElse), Array[_Part], Bool)],
     else_if: _ElseIfNode
   ): Array[_Part]? =>
     (let stmt, let if_body, _) = open.pop()?
@@ -290,8 +330,15 @@ class val Template
       let else_if_body = Array[_Part]
       open.push((_IfNode(else_if.value), else_if_body, false))
       else_if_body
+    | let ifnot: _IfNotNode =>
+      let else_body = Array[_Part]
+      open.push(
+        (_IfElse(ifnot.value, if_body where negated' = true), else_body, true))
+      let else_if_body = Array[_Part]
+      open.push((_IfNode(else_if.value), else_if_body, false))
+      else_if_body
     else
-      error // elseif only valid inside an if block
+      error // elseif only valid inside an if or ifnot block
     end
 
   fun render(values: TemplateValues box): String? =>
@@ -321,6 +368,22 @@ class val Template
           | let eb: Array[_Part] box =>
             result = result + _render_parts(eb, values)?
           end
+        end
+      | let ifnot: _IfNot box =>
+        if
+          try
+            values._lookup(ifnot.value)?
+            true
+          else
+            false
+          end
+        then
+          match ifnot.else_body
+          | let eb: Array[_Part] box =>
+            result = result + _render_parts(eb, values)?
+          end
+        else
+          result = result + _render_parts(ifnot.body, values)?
         end
       | let ifnotempty: _IfNotEmpty box =>
         if values._lookup(ifnotempty.value)?.values().has_next() then


### PR DESCRIPTION
`ifnot` renders its body when a variable is absent — the logical inverse of `if`. Without it, the only way to show content for a missing variable was to write an `if`/`else` and leave the `if` branch empty, which reads backwards. Now the absent case can be the primary branch.

```pony
// Show "Anonymous" when name is missing
let t = Template.parse("{{ ifnot name }}Anonymous{{ end }}")?

// Or with an else for the present case
let t = Template.parse(
  "{{ ifnot name }}Anonymous{{ else }}{{ name }}{{ end }}")?
```

`ifnot` supports `else` and `elseif` for consistency with `if`. The parser slots `ifnot` between `ifnotempty` and `if` in the PEG ordered-choice so the longer prefix still wins. The `_IfElse` marker gains a `negated` field to track whether the enclosing block was `if` or `ifnot`, avoiding a separate `_IfNotElse` class.

Originates from Discussion #38.