### PR TITLE
Unify `if` and `ifnotempty` conditionals

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -11,9 +11,11 @@ let t = Template.parse(
 
 `elseif` chains can be as long as needed. A final `else` branch is optional and renders when no condition matches.
 
+`if` checks both existence and non-emptiness: a variable bound to an empty sequence is falsy, so `{{ if items }}` naturally guards a loop without a separate check.
+
 ## Add `ifnot` negated conditional blocks
 
-`ifnot` renders its body when a variable is absent — the logical inverse of `if`. This lets you write the "missing" case as the primary branch instead of requiring an `if`/`else` just to get at the `else`.
+`ifnot` renders its body when a variable is absent or is an empty sequence — the logical inverse of `if`. This lets you write the "missing" case as the primary branch instead of requiring an `if`/`else` just to get at the `else`.
 
 ```pony
 let t = Template.parse(
@@ -26,4 +28,3 @@ Like `if`, `ifnot` supports `else` and `elseif` branches:
 let t = Template.parse(
   "{{ ifnot name }}Anonymous{{ else }}{{ name }}{{ end }}")?
 ```
-

--- a/.release-notes/unify-if-and-ifnotempty.md
+++ b/.release-notes/unify-if-and-ifnotempty.md
@@ -1,0 +1,25 @@
+## Unify `if` and `ifnotempty` conditionals
+
+`ifnotempty` has been removed. `if` now checks both existence and sequence non-emptiness, making `ifnotempty` redundant.
+
+Before:
+
+```pony
+let t = Template.parse(
+  "{{ ifnotempty items }}{{ for i in items }}{{ i }}{{ end }}{{ end }}")?
+```
+
+After:
+
+```pony
+let t = Template.parse(
+  "{{ if items }}{{ for i in items }}{{ i }}{{ end }}{{ end }}")?
+```
+
+Unlike `ifnotempty`, `if` supports `else` and `elseif` branches:
+
+```pony
+let t = Template.parse(
+  "{{ if items }}{{ for i in items }}{{ i }}{{ end }}" +
+  "{{ else }}no items{{ end }}")?
+```

--- a/README.md
+++ b/README.md
@@ -49,11 +49,8 @@ As templates gets used in more projects, we expect to find and fix bugs. We also
 * For loops: `{{ for x in xs }}{{ x }} {{ end }}` will iterate through the
   sequence `xs` and adds each element plus a space to the output.
 * Conditional output: `{{ if spam }}Eggs{{ end }}` only adds `Eggs` to the
-  output if the variable `spam` exists. Can also check for the presence of a
-  property.
-
-  `{{ ifnotempty seq }}` ignores everything until the next `{{ end }}` if
-  sequence ``seq`` is empty.
+  output if the variable `spam` exists and, for sequences, is non-empty.
+  Can also check for the presence of a property.
 * Calls: `{{ escape(var) }}` calls `escape` with argument `var` and adds
   the function result to the output. All known functions must be passed as part
   of a `TemplateContext` value to the template's constructor.

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ Parses a template with a single placeholder, binds a value, and renders the resu
 
 ## [conditionals-example](conditionals-example/)
 
-Shows how to use `if`/`else`, `if`/`elseif`/`else`, and `ifnot` blocks to conditionally include content based on whether values are present or absent. Demonstrates simple two-branch conditionals, chained multi-branch selection, and negated conditionals for the absent-variable case.
+Shows how to use `if`/`else`, `if`/`elseif`/`else`, and `ifnot` blocks to conditionally include content based on whether values are present or absent. Demonstrates simple two-branch conditionals, chained multi-branch selection, negated conditionals, and sequence truthiness (guarding a loop with `if` so it only renders when items are present).
 
 ## [functions-example](functions-example/)
 

--- a/examples/conditionals-example/conditionals-example.pony
+++ b/examples/conditionals-example/conditionals-example.pony
@@ -1,8 +1,9 @@
-// This example demonstrates if/else, if/elseif/else, and ifnot conditional
-// blocks
+// This example demonstrates if/else, if/elseif/else, ifnot, and sequence
+// truthiness in conditional blocks
 
 // In your code this `use` statement would be:
 // use "templates"
+use "collections"
 use "../../templates"
 
 actor Main
@@ -83,3 +84,27 @@ actor Main
 
     // With a name → "Alice"
     try env.out.print(display_name.render(with_name)?) end
+
+    // Sequence truthiness: `if` checks both existence and non-emptiness.
+    // Use `if` to guard a loop so it only renders when items are present.
+    let items_list =
+      try
+        Template.parse(
+          "{{ if items }}Items: {{ for i in items }}{{ i }} {{ end }}" +
+          "{{ else }}No items{{ end }}")?
+      else
+        env.err.print("Could not parse template :(")
+        env.exitcode(1)
+        return
+      end
+
+    // Non-empty sequence → "Items: a b c "
+    let with_items = TemplateValues
+    with_items("items") = TemplateValue(
+      [TemplateValue("a"); TemplateValue("b"); TemplateValue("c")])
+    try env.out.print(items_list.render(with_items)?) end
+
+    // Empty sequence → "No items"
+    let no_items = TemplateValues
+    no_items("items") = TemplateValue(Array[TemplateValue])
+    try env.out.print(items_list.render(no_items)?) end

--- a/templates/_test.pony
+++ b/templates/_test.pony
@@ -14,7 +14,6 @@ actor \nodoc\ Main is TestList
     test(_TemplateTest)
     test(_LoopTest)
     test(_IfTest)
-    test(_IfNotEmptyTest)
     test(_CallTest)
     test(_StmtParserTest)
 
@@ -32,7 +31,6 @@ actor \nodoc\ Main is TestList
     test(Property1UnitTest[String](_PropValidLoopParsesToLoopNode))
     test(Property1UnitTest[String](_PropValidIfParsesToIfNode))
     test(Property1UnitTest[String](_PropValidIfNotParsesToIfNotNode))
-    test(Property1UnitTest[String](_PropValidIfNotEmptyParsesToIfNotEmptyNode))
     test(Property1UnitTest[String](_PropValidElseIfParsesToElseIfNode))
     test(Property1UnitTest[box->String](_PropInvalidStmtErrors))
     test(_TestParserNodeFields)
@@ -53,7 +51,10 @@ actor \nodoc\ Main is TestList
     test(Property1UnitTest[String](_PropMissingVariableRendersEmpty))
     test(_TestRenderNestedLoop)
     test(_TestRenderLoopWithIf)
-    test(_TestRenderIfNotEmptyWithLoop)
+    test(_TestRenderIfWithSequence)
+    test(_TestRenderIfElseWithSequence)
+    test(_TestRenderIfNotWithSequence)
+    test(_TestRenderIfGuardingLoop)
     test(_TestRenderAdjacentPlaceholders)
     test(_TestRenderLoopVariableShadowing)
 
@@ -183,12 +184,6 @@ primitive \nodoc\ _Generators
     """
     valid_prop_stmt().map[String]({(prop) => "ifnot " + prop })
 
-  fun valid_ifnotempty_stmt(): Generator[String] =>
-    """
-    Generates `ifnotempty prop` — an ifnotempty statement.
-    """
-    valid_prop_stmt().map[String]({(prop) => "ifnotempty " + prop })
-
   fun valid_elseif_stmt(): Generator[String] =>
     """
     Generates `elseif prop` — an elseif statement.
@@ -299,21 +294,6 @@ class \nodoc\ iso _IfTest is UnitTest
     h.assert_eq[String]("Eggs", template.render(values)?)
 
 
-class \nodoc\ iso _IfNotEmptyTest is UnitTest
-  fun name(): String => "Template ifnotempty"
-
-  fun apply(h: TestHelper)? =>
-    let values = TemplateValues
-    values("seqempty") = TemplateValue([])
-    values("seq") = TemplateValue([TemplateValue("spam")])
-    let not_template = Template.parse(
-      """
-      {{ ifnotempty seqempty }}Should not be rendered{{ end }}
-      {{ ifnotempty seq}}Values: {{ for x in seq }}{{x}}{{ end}}{{ end }}
-      """)?
-    h.assert_eq[String]("\nValues: spam\n", not_template.render(values)?)
-
-
 class \nodoc\ iso _CallTest is UnitTest
   fun name(): String => "Template calls"
 
@@ -340,8 +320,6 @@ class \nodoc\ iso _StmtParserTest is UnitTest
       {()? => _StmtParser.parse("foo(spam.eggs)")? as _CallNode })
     h.assert_no_error(
       {()? => _StmtParser.parse("ifnot spam")? as _IfNotNode })
-    h.assert_no_error(
-      {()? => _StmtParser.parse("ifnotempty spam")? as _IfNotEmptyNode })
 
 
 // ---------------------------------------------------------------------------
@@ -498,18 +476,6 @@ class \nodoc\ iso _PropValidIfNotParsesToIfNotNode is Property1[String]
     _StmtParser.parse(stmt)? as _IfNotNode
 
 
-class \nodoc\ iso _PropValidIfNotEmptyParsesToIfNotEmptyNode
-  is Property1[String]
-  fun name(): String =>
-    "Parser: valid ifnotempty parses to _IfNotEmptyNode"
-
-  fun gen(): Generator[String] =>
-    _Generators.valid_ifnotempty_stmt()
-
-  fun ref property(stmt: String, h: PropertyHelper) ? =>
-    _StmtParser.parse(stmt)? as _IfNotEmptyNode
-
-
 class \nodoc\ iso _PropValidElseIfParsesToElseIfNode is Property1[String]
   fun name(): String => "Parser: valid elseif parses to _ElseIfNode"
 
@@ -596,14 +562,6 @@ class \nodoc\ iso _TestParserNodeFields is UnitTest
     else h.fail("expected _IfNotNode"); error
     end
 
-    // "ifnotempty seq" → _IfNotEmptyNode(value=_PropNode("seq", []))
-    match _StmtParser.parse("ifnotempty seq")?
-    | let i: _IfNotEmptyNode =>
-      h.assert_eq[String]("seq", i.value.name)
-      h.assert_eq[USize](0, i.value.props.size())
-    else h.fail("expected _IfNotEmptyNode"); error
-    end
-
     // "  foo  " → _PropNode(name="foo") (whitespace stripped)
     match _StmtParser.parse("  foo  ")?
     | let p: _PropNode =>
@@ -655,11 +613,11 @@ class \nodoc\ iso _TestParserKeywordAmbiguity is UnitTest
       end
     })
 
-    // "ifnotemptyxyz" → _IfNotEmptyNode(value=_PropNode("xyz"))
+    // "ifnotemptyxyz" → _IfNotNode(value=_PropNode("emptyxyz"))
     h.assert_no_error({() ? =>
       match _StmtParser.parse("ifnotemptyxyz")?
-      | let i: _IfNotEmptyNode =>
-        if i.value.name != "xyz" then error end
+      | let i: _IfNotNode =>
+        if i.value.name != "emptyxyz" then error end
       else error
       end
     })
@@ -733,9 +691,6 @@ class \nodoc\ iso _TestParseErrorUnclosedBlock is UnitTest
       Template.parse("{{ ifnot flag }}body")?
     })
     h.assert_error({() ? =>
-      Template.parse("{{ ifnotempty seq }}body")?
-    })
-    h.assert_error({() ? =>
       Template.parse("{{ for x in xs }}{{ if y }}nested")?
     })
 
@@ -803,16 +758,6 @@ class \nodoc\ iso _TestParseErrorElseElseIf is UnitTest
     // elseif in a for loop
     h.assert_error({() ? =>
       Template.parse("{{ for x in xs }}{{ elseif y }}{{ end }}")?
-    })
-
-    // else in an ifnotempty block
-    h.assert_error({() ? =>
-      Template.parse("{{ ifnotempty seq }}{{ else }}{{ end }}")?
-    })
-
-    // elseif in an ifnotempty block
-    h.assert_error({() ? =>
-      Template.parse("{{ ifnotempty seq }}{{ elseif y }}{{ end }}")?
     })
 
     // Double else in ifnot
@@ -935,24 +880,82 @@ class \nodoc\ iso _TestRenderLoopWithIf is UnitTest
     h.assert_eq[String]("*", template.render(values)?)
 
 
-class \nodoc\ iso _TestRenderIfNotEmptyWithLoop is UnitTest
-  fun name(): String => "Render: ifnotempty guarding a loop"
+class \nodoc\ iso _TestRenderIfWithSequence is UnitTest
+  fun name(): String => "Render: if with sequence truthiness"
 
   fun apply(h: TestHelper)? =>
-    // Non-empty case
-    let values = TemplateValues
-    values("items") = TemplateValue(
-      [TemplateValue("x"); TemplateValue("y")])
+    let template = Template.parse("{{ if items }}yes{{ end }}")?
+
+    // Empty sequence → falsy, renders empty
+    let v1 = TemplateValues
+    v1("items") = TemplateValue([])
+    h.assert_eq[String]("", template.render(v1)?)
+
+    // Non-empty sequence → truthy, renders body
+    let v2 = TemplateValues
+    v2("items") = TemplateValue([TemplateValue("a")])
+    h.assert_eq[String]("yes", template.render(v2)?)
+
+    // String value → truthy, renders body (unchanged behavior)
+    let v3 = TemplateValues
+    v3("items") = "hello"
+    h.assert_eq[String]("yes", template.render(v3)?)
+
+
+class \nodoc\ iso _TestRenderIfElseWithSequence is UnitTest
+  fun name(): String => "Render: if/else with empty sequence falls to else"
+
+  fun apply(h: TestHelper)? =>
     let template = Template.parse(
-      "{{ ifnotempty items }}" +
+      "{{ if items }}has items{{ else }}no items{{ end }}")?
+
+    // Empty sequence → else branch
+    let v1 = TemplateValues
+    v1("items") = TemplateValue([])
+    h.assert_eq[String]("no items", template.render(v1)?)
+
+    // Non-empty sequence → if body
+    let v2 = TemplateValues
+    v2("items") = TemplateValue([TemplateValue("a")])
+    h.assert_eq[String]("has items", template.render(v2)?)
+
+
+class \nodoc\ iso _TestRenderIfNotWithSequence is UnitTest
+  fun name(): String => "Render: ifnot with sequence truthiness"
+
+  fun apply(h: TestHelper)? =>
+    let template = Template.parse("{{ ifnot items }}empty{{ end }}")?
+
+    // Empty sequence → ifnot body rendered
+    let v1 = TemplateValues
+    v1("items") = TemplateValue([])
+    h.assert_eq[String]("empty", template.render(v1)?)
+
+    // Non-empty sequence → empty
+    let v2 = TemplateValues
+    v2("items") = TemplateValue([TemplateValue("a")])
+    h.assert_eq[String]("", template.render(v2)?)
+
+
+class \nodoc\ iso _TestRenderIfGuardingLoop is UnitTest
+  fun name(): String => "Render: if guarding a loop with sequences"
+
+  fun apply(h: TestHelper)? =>
+    let template = Template.parse(
+      "{{ if items }}" +
       "{{ for i in items }}{{ i }}{{ end }}" +
       "{{ end }}")?
-    h.assert_eq[String]("xy", template.render(values)?)
+
+    // Non-empty case
+    let v1 = TemplateValues
+    v1("items") = TemplateValue(
+      [TemplateValue("x"); TemplateValue("y")])
+    h.assert_eq[String]("xy", template.render(v1)?)
 
     // Empty case
-    let values2 = TemplateValues
-    values2("items") = TemplateValue([])
-    h.assert_eq[String]("", template.render(values2)?)
+    let v2 = TemplateValues
+    v2("items") = TemplateValue([])
+    h.assert_eq[String]("", template.render(v2)?)
 
 
 class \nodoc\ iso _TestRenderAdjacentPlaceholders is UnitTest

--- a/templates/parser.pony
+++ b/templates/parser.pony
@@ -8,7 +8,6 @@ primitive _TLoop is Label fun text(): String => "Loop"
 primitive _TEnd is Label fun text(): String => "End"
 primitive _TIf is Label fun text(): String => "If"
 primitive _TIfNot is Label fun text(): String => "IfNot"
-primitive _TIfNotEmpty is Label fun text(): String => "IfNotEmpty"
 primitive _TElse is Label fun text(): String => "Else"
 primitive _TElseIf is Label fun text(): String => "ElseIf"
 
@@ -49,12 +48,6 @@ class box _IfNotNode
   new box create(value': _PropNode) =>
     value = value'
 
-class box _IfNotEmptyNode
-  let value: _PropNode
-
-  new box create(value': _PropNode) =>
-    value = value'
-
 class box _LoopNode
   let target: String
   let source: _PropNode
@@ -65,7 +58,7 @@ class box _LoopNode
 
 type _StmtNode is
   ( _EndNode | _ElseNode | _ElseIfNode
-  | _PropNode | _CallNode | _IfNode | _IfNotNode | _IfNotEmptyNode
+  | _PropNode | _CallNode | _IfNode | _IfNotNode
   | _LoopNode )
 
 primitive _StmtParser
@@ -84,13 +77,12 @@ primitive _StmtParser
       let whitespace = (L(" ") / L("\t")).many1()
       let end' = L("end").term(_TEnd)
       let loop = (L("for") * name * L("in") * prop).node(_TLoop).hide(whitespace)
-      let ifnotempty = (L("ifnotempty") * prop).node(_TIfNotEmpty).hide(whitespace)
       let ifnot = (L("ifnot") * prop).node(_TIfNot).hide(whitespace)
       let else_if = (L("elseif") * prop).node(_TElseIf).hide(whitespace)
       let else' = L("else").term(_TElse)
       let if' = (L("if") * prop).node(_TIf).hide(whitespace)
 
-      let stmt = ifnotempty / ifnot / if' / loop / else_if / else' / end' / expr
+      let stmt = ifnot / if' / loop / else_if / else' / end' / expr
       stmt
     end
 
@@ -105,7 +97,6 @@ primitive _StmtParser
       match ast.label()
       | let if': _TIf => _parse_if(ast as AST)?
       | let ifnot: _TIfNot => _parse_ifnot(ast as AST)?
-      | let ifnotempty: _TIfNotEmpty => _parse_ifnotempty(ast as AST)?
       | let _: _TElse => _ElseNode
       | let _: _TElseIf => _parse_elseif(ast as AST)?
       | let _: _TEnd => _EndNode
@@ -127,9 +118,6 @@ primitive _StmtParser
 
   fun _parse_ifnot(ast: AST): _IfNotNode? =>
     _IfNotNode(_parse_prop(ast.children(1)? as AST)?)
-
-  fun _parse_ifnotempty(ast: AST): _IfNotEmptyNode? =>
-    _IfNotEmptyNode(_parse_prop(ast.children(1)? as AST)?)
 
   fun _parse_elseif(ast: AST): _ElseIfNode? =>
     _ElseIfNode(_parse_prop(ast.children(1)? as AST)?)

--- a/templates/template.pony
+++ b/templates/template.pony
@@ -6,10 +6,11 @@ blocks. Supported block types:
 
 * **Variable substitution**: `{{ name }}` or `{{ obj.prop }}`
 * **Conditionals**: `{{ if flag }}...{{ end }}`, with optional
-  `{{ else }}` and `{{ elseif other }}` branches
+  `{{ else }}` and `{{ elseif other }}` branches. Truthy when the variable
+  exists and, for sequences, is non-empty.
 * **Negated conditionals**: `{{ ifnot flag }}...{{ end }}`, renders when
-  the variable is absent; supports `{{ else }}` and `{{ elseif }}`
-* **Existence check**: `{{ ifnotempty seq }}...{{ end }}`
+  the variable is absent or is an empty sequence; supports `{{ else }}`
+  and `{{ elseif }}`
 * **Loops**: `{{ for item in items }}...{{ end }}`
 * **Function calls**: `{{ fn(arg) }}` using functions registered via
   `TemplateContext`
@@ -78,14 +79,6 @@ class _IfNot
     body = body'
     else_body = else_body'
 
-class _IfNotEmpty
-  let value: _PropNode
-  let body: Array[_Part] box
-
-  new box create(value': _PropNode, body': Array[_Part] box) =>
-    value = value'
-    body = body'
-
 class _Loop
   let target: String
   let source: _PropNode
@@ -98,7 +91,7 @@ class _Loop
 
 type _Part is
   ( (_Literal, String) | _Call box | _PropNode
-  | _If box | _IfNot box | _IfNotEmpty box | _Loop box )
+  | _If box | _IfNot box | _Loop box )
 
 
 class box TemplateValue
@@ -129,6 +122,12 @@ class box TemplateValue
   fun string(): String? => _value as String
 
   fun values(): Iterator[TemplateValue] => _values.values()
+
+  fun box _is_truthy(): Bool =>
+    match _value
+    | let _: String => true
+    else _values.values().has_next()
+    end
 
 
 class TemplateValues
@@ -206,7 +205,7 @@ class val Template
   fun tag _parse(source: String, ctx: TemplateContext val): Array[_Part] box? =>
     var parts: Array[_Part] = []
     var current_parts = parts
-    var open: Array[((_IfNode | _IfNotNode | _IfNotEmptyNode | _LoopNode | _IfElse), Array[_Part], Bool)] = []
+    var open: Array[((_IfNode | _IfNotNode | _LoopNode | _IfElse), Array[_Part], Bool)] = []
     var prev_end: ISize = 0
     while prev_end < source.size().isize() do
       let start_pos =
@@ -235,9 +234,6 @@ class val Template
       | let ifnot: _IfNotNode =>
         current_parts = Array[_Part]
         open.push((ifnot, current_parts, false))
-      | let ifnotempty: _IfNotEmptyNode =>
-        current_parts = Array[_Part]
-        open.push((ifnotempty, current_parts, false))
       | let loop: _LoopNode =>
         current_parts = Array[_Part]
         open.push((loop, current_parts, false))
@@ -255,7 +251,7 @@ class val Template
     consume parts
 
   fun tag _parse_end(
-    open: Array[((_IfNode | _IfNotNode | _IfNotEmptyNode | _LoopNode | _IfElse), Array[_Part], Bool)],
+    open: Array[((_IfNode | _IfNotNode | _LoopNode | _IfElse), Array[_Part], Bool)],
     parts: Array[_Part]
   ): Array[_Part]? =>
     (let stmt, let body, _) = open.pop()?
@@ -268,7 +264,6 @@ class val Template
         if ie.negated then _IfNot(ie.value, ie.if_body, body)
         else _If(ie.value, ie.if_body, body)
         end
-      | let ifnotempty: _IfNotEmptyNode => _IfNotEmpty(ifnotempty.value, body)
       | let loop: _LoopNode => _Loop(loop.target, loop.source, body)
       end
 
@@ -301,7 +296,7 @@ class val Template
     next_current
 
   fun tag _parse_else(
-    open: Array[((_IfNode | _IfNotNode | _IfNotEmptyNode | _LoopNode | _IfElse), Array[_Part], Bool)]
+    open: Array[((_IfNode | _IfNotNode | _LoopNode | _IfElse), Array[_Part], Bool)]
   ): Array[_Part]? =>
     (let stmt, let if_body, _) = open.pop()?
     match stmt
@@ -319,7 +314,7 @@ class val Template
     end
 
   fun tag _parse_elseif_stmt(
-    open: Array[((_IfNode | _IfNotNode | _IfNotEmptyNode | _LoopNode | _IfElse), Array[_Part], Bool)],
+    open: Array[((_IfNode | _IfNotNode | _LoopNode | _IfElse), Array[_Part], Bool)],
     else_if: _ElseIfNode
   ): Array[_Part]? =>
     (let stmt, let if_body, _) = open.pop()?
@@ -360,8 +355,13 @@ class val Template
         let substitution = try values._lookup(prop)?.string()? else "" end
         result = result + substitution
       | let if': _If box =>
-        try
-          values._lookup(if'.value)?
+        if
+          try
+            values._lookup(if'.value)?._is_truthy()
+          else
+            false
+          end
+        then
           result = result + _render_parts(if'.body, values)?
         else
           match if'.else_body
@@ -372,8 +372,7 @@ class val Template
       | let ifnot: _IfNot box =>
         if
           try
-            values._lookup(ifnot.value)?
-            true
+            values._lookup(ifnot.value)?._is_truthy()
           else
             false
           end
@@ -384,10 +383,6 @@ class val Template
           end
         else
           result = result + _render_parts(ifnot.body, values)?
-        end
-      | let ifnotempty: _IfNotEmpty box =>
-        if values._lookup(ifnotempty.value)?.values().has_next() then
-          result = result + _render_parts(ifnotempty.body, values)?
         end
       | let loop: _Loop box =>
         for value in values._lookup(loop.source)?.values() do


### PR DESCRIPTION
`if` now checks both existence and sequence non-emptiness, making `ifnotempty` redundant and removing it. Empty sequences are falsy, so `{{ if items }}` naturally guards a loop. `ifnot` is the logical negation: truthy when absent or an empty sequence.

This gives `if` blocks `else`/`elseif` support for the sequence case, which `ifnotempty` never had. `{{ ifnotempty x }}` is now a parse error — users migrate to `{{ if x }}`.