### PR TITLE
Add `include` partials

### DIFF
--- a/.release-notes/add-include-partials.md
+++ b/.release-notes/add-include-partials.md
@@ -1,0 +1,20 @@
+## Add `include` partials
+
+Templates can now reuse shared fragments via `{{ include "name" }}`. Partials are raw template strings registered in `TemplateContext` and inlined at parse time. They share the calling template's variable scope and can contain any block type (variables, loops, conditionals). Circular includes are detected at parse time.
+
+```pony
+let ctx = TemplateContext(
+  recover Map[String, {(String): String}] end,
+  recover val
+    let p = Map[String, String]
+    p("header") = "=== {{ title }} ==="
+    p
+  end
+)
+
+let template = Template.parse(
+  "{{ include \"header\" }}\n{{ for item in items }}{{ item }}\n{{ end }}",
+  ctx)?
+```
+
+Partial names may contain letters, digits, underscores, and hyphens (`[a-zA-Z0-9_-]+`).

--- a/README.md
+++ b/README.md
@@ -54,3 +54,7 @@ As templates gets used in more projects, we expect to find and fix bugs. We also
 * Calls: `{{ escape(var) }}` calls `escape` with argument `var` and adds
   the function result to the output. All known functions must be passed as part
   of a `TemplateContext` value to the template's constructor.
+* Includes: `{{ include "header" }}` inlines a named partial registered via
+  `TemplateContext`. Partials share the same variable scope as the surrounding
+  template and can contain any block type. Circular includes are detected at
+  parse time.

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,3 +13,7 @@ Shows how to use `if`/`else`, `if`/`elseif`/`else`, and `ifnot` blocks to condit
 ## [functions-example](functions-example/)
 
 Registers a custom function via `TemplateContext` and calls it from within a template inside a `for` loop. Demonstrates how to extend templates with user-defined transformations.
+
+## [include-example](include-example/)
+
+Registers named partials via `TemplateContext` and inlines them with `{{ include "name" }}`. Demonstrates reusing template fragments across templates, with partials sharing the same variable scope.

--- a/examples/include-example/include-example.pony
+++ b/examples/include-example/include-example.pony
@@ -1,0 +1,56 @@
+// This example demonstrates how to use partials (includes) to reuse template
+// fragments across templates
+
+// In your code this `use` statement would be:
+// use "templates"
+use "../../templates"
+
+use "collections"
+
+actor Main
+  new create(env: Env) =>
+    // Partials are raw template strings registered in a TemplateContext.
+    // They can contain any template syntax — variables, loops, conditionals.
+    let ctx = TemplateContext(
+      recover Map[String, {(String): String}] end,
+      recover val
+        let p = Map[String, String]
+        p("header") = "=== {{ title }} ==="
+        p("user-line") = "- {{ user }} ({{ user.role }})"
+        p
+      end
+    )
+
+    // Use {{ include "name" }} to inline a partial. The partial shares the
+    // same variable scope as the surrounding template.
+    let template =
+      try
+        Template.parse(
+          "{{ include \"header\" }}\n" +
+          "{{ for user in users }}{{ include \"user-line\" }}\n{{ end }}",
+          ctx)?
+      else
+        env.err.print("Could not parse template :(")
+        env.exitcode(1)
+        return
+      end
+
+    let values = TemplateValues
+    values("title") = "Team Members"
+
+    let alice_props = Map[String, TemplateValue]
+    alice_props("role") = TemplateValue("admin")
+    let bob_props = Map[String, TemplateValue]
+    bob_props("role") = TemplateValue("member")
+
+    values("users") = TemplateValue(
+      [TemplateValue("Alice", alice_props)
+       TemplateValue("Bob", bob_props)])
+
+    try
+      env.out.print(template.render(values)?)
+    else
+      env.err.print("Could not render template :(")
+      env.exitcode(1)
+      return
+    end

--- a/templates/_test.pony
+++ b/templates/_test.pony
@@ -79,6 +79,23 @@ actor \nodoc\ Main is TestList
     test(_TestCallArgMissing)
     test(_TestCallMultipleFunctions)
 
+    // Include parser tests
+    test(Property1UnitTest[String](_PropValidIncludeParsesToIncludeNode))
+    test(_TestParserIncludeNodeFields)
+    test(_TestParserIncludeKeywordAmbiguity)
+
+    // Include parse error tests
+    test(_TestParseErrorMissingPartial)
+    test(_TestParseErrorCircularInclude)
+
+    // Include render tests
+    test(_TestRenderInclude)
+    test(_TestRenderIncludeInsideIf)
+    test(_TestRenderIncludeInsideLoop)
+    test(_TestRenderNestedIncludes)
+    test(_TestRenderMultipleIncludes)
+    test(_TestRenderIncludeWithBlocks)
+
     // from_file test (Step 8)
     test(_TestFromFile)
 
@@ -190,6 +207,25 @@ primitive \nodoc\ _Generators
     """
     valid_prop_stmt().map[String]({(prop) => "elseif " + prop })
 
+  fun valid_include_stmt(): Generator[String] =>
+    """
+    Generates `include "name"` where name matches `[a-zA-Z0-9_-]+`.
+    """
+    let chars: String val =
+      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+    Generator[String](
+      object is GenObj[String]
+        fun generate(rnd: Randomness): String^ =>
+          let len = rnd.usize(1, 20)
+          let name = recover iso String(len) end
+          var i: USize = 0
+          while i < len do
+            try name.push(chars(rnd.usize(0, chars.size() - 1))?) end
+            i = i + 1
+          end
+          "include \"" + consume name + "\""
+      end)
+
   fun invalid_stmt(): Generator[box->String] =>
     """
     Generates invalid statement strings, one per distinct failure mode.
@@ -206,6 +242,8 @@ primitive \nodoc\ _Generators
       ".foo"       // leading dot
       "for x y z"  // invalid loop syntax
       "end."       // trailing dot after end
+      "include \"\"" // empty include name
+      "include \""   // unclosed quote
     ])
 
   fun literal_text(): Generator[String] =>
@@ -1320,6 +1358,231 @@ class \nodoc\ iso _TestCallMultipleFunctions is UnitTest
     let template = Template.parse(
       "{{ double(x) }}-{{ rev(y) }}", ctx)?
     h.assert_eq[String]("abab-dc", template.render(values)?)
+
+
+// ---------------------------------------------------------------------------
+// Include parser tests
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _PropValidIncludeParsesToIncludeNode is Property1[String]
+  fun name(): String => "Parser: valid include parses to _IncludeNode"
+
+  fun gen(): Generator[String] =>
+    _Generators.valid_include_stmt()
+
+  fun ref property(stmt: String, h: PropertyHelper) ? =>
+    _StmtParser.parse(stmt)? as _IncludeNode
+
+
+class \nodoc\ iso _TestParserIncludeNodeFields is UnitTest
+  fun name(): String => "Parser: include node field correctness"
+
+  fun apply(h: TestHelper)? =>
+    // include "header" → _IncludeNode(name="header")
+    match _StmtParser.parse("include \"header\"")?
+    | let inc: _IncludeNode =>
+      h.assert_eq[String]("header", inc.name)
+    else h.fail("expected _IncludeNode"); error
+    end
+
+    // include "my-partial" → name with hyphen
+    match _StmtParser.parse("include \"my-partial\"")?
+    | let inc: _IncludeNode =>
+      h.assert_eq[String]("my-partial", inc.name)
+    else h.fail("expected _IncludeNode with hyphen"); error
+    end
+
+    // include "a1_b2" → name with digits and underscores
+    match _StmtParser.parse("include \"a1_b2\"")?
+    | let inc: _IncludeNode =>
+      h.assert_eq[String]("a1_b2", inc.name)
+    else h.fail("expected _IncludeNode with digits"); error
+    end
+
+
+class \nodoc\ iso _TestParserIncludeKeywordAmbiguity is UnitTest
+  fun name(): String => "Parser: include keyword ambiguity"
+
+  fun apply(h: TestHelper) =>
+    // bare "include" → _PropNode (no quoted string follows)
+    h.assert_no_error({() ? =>
+      _StmtParser.parse("include")? as _PropNode
+    })
+
+    // "includefoo" → _PropNode (no space + quote)
+    h.assert_no_error({() ? =>
+      _StmtParser.parse("includefoo")? as _PropNode
+    })
+
+
+// ---------------------------------------------------------------------------
+// Include parse error tests
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _TestParseErrorMissingPartial is UnitTest
+  fun name(): String => "Template parse error: missing partial"
+
+  fun apply(h: TestHelper) =>
+    h.assert_error({() ? =>
+      Template.parse("{{ include \"missing\" }}")?
+    })
+
+
+class \nodoc\ iso _TestParseErrorCircularInclude is UnitTest
+  fun name(): String => "Template parse error: circular include"
+
+  fun apply(h: TestHelper) =>
+    // Self-include
+    h.assert_error({() ? =>
+      let partials = recover val
+        let m = Map[String, String]
+        m("self") = "{{ include \"self\" }}"
+        m
+      end
+      let ctx = TemplateContext(
+        recover Map[String, {(String): String}] end, partials)
+      Template.parse("{{ include \"self\" }}", ctx)?
+    })
+
+    // Mutual cycle: a includes b, b includes a
+    h.assert_error({() ? =>
+      let partials = recover val
+        let m = Map[String, String]
+        m("a") = "{{ include \"b\" }}"
+        m("b") = "{{ include \"a\" }}"
+        m
+      end
+      let ctx = TemplateContext(
+        recover Map[String, {(String): String}] end, partials)
+      Template.parse("{{ include \"a\" }}", ctx)?
+    })
+
+
+// ---------------------------------------------------------------------------
+// Include render tests
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _TestRenderInclude is UnitTest
+  fun name(): String => "Render: basic include with variable substitution"
+
+  fun apply(h: TestHelper)? =>
+    let partials = recover val
+      let m = Map[String, String]
+      m("greeting") = "Hello {{ name }}!"
+      m
+    end
+    let ctx = TemplateContext(
+      recover Map[String, {(String): String}] end, partials)
+    let template = Template.parse(">> {{ include \"greeting\" }} <<", ctx)?
+    let values = TemplateValues
+    values("name") = "world"
+    h.assert_eq[String](">> Hello world! <<", template.render(values)?)
+
+
+class \nodoc\ iso _TestRenderIncludeInsideIf is UnitTest
+  fun name(): String => "Render: include inside conditional"
+
+  fun apply(h: TestHelper)? =>
+    let partials = recover val
+      let m = Map[String, String]
+      m("badge") = "[{{ role }}]"
+      m
+    end
+    let ctx = TemplateContext(
+      recover Map[String, {(String): String}] end, partials)
+    let template = Template.parse(
+      "{{ if role }}{{ include \"badge\" }}{{ end }}", ctx)?
+
+    // With role
+    let v1 = TemplateValues
+    v1("role") = "admin"
+    h.assert_eq[String]("[admin]", template.render(v1)?)
+
+    // Without role
+    h.assert_eq[String]("", template.render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestRenderIncludeInsideLoop is UnitTest
+  fun name(): String => "Render: include inside loop"
+
+  fun apply(h: TestHelper)? =>
+    let partials = recover val
+      let m = Map[String, String]
+      m("item") = "<{{ x }}>"
+      m
+    end
+    let ctx = TemplateContext(
+      recover Map[String, {(String): String}] end, partials)
+    let template = Template.parse(
+      "{{ for x in items }}{{ include \"item\" }}{{ end }}", ctx)?
+    let values = TemplateValues
+    values("items") = TemplateValue(
+      [TemplateValue("a"); TemplateValue("b"); TemplateValue("c")])
+    h.assert_eq[String]("<a><b><c>", template.render(values)?)
+
+
+class \nodoc\ iso _TestRenderNestedIncludes is UnitTest
+  fun name(): String => "Render: nested includes (A includes B includes C)"
+
+  fun apply(h: TestHelper)? =>
+    let partials = recover val
+      let m = Map[String, String]
+      m("a") = "[{{ include \"b\" }}]"
+      m("b") = "({{ include \"c\" }})"
+      m("c") = "{{ x }}"
+      m
+    end
+    let ctx = TemplateContext(
+      recover Map[String, {(String): String}] end, partials)
+    let template = Template.parse("{{ include \"a\" }}", ctx)?
+    let values = TemplateValues
+    values("x") = "deep"
+    h.assert_eq[String]("[(deep)]", template.render(values)?)
+
+
+class \nodoc\ iso _TestRenderMultipleIncludes is UnitTest
+  fun name(): String => "Render: multiple includes in one template"
+
+  fun apply(h: TestHelper)? =>
+    let partials = recover val
+      let m = Map[String, String]
+      m("header") = "=={{ title }}=="
+      m("footer") = "--end--"
+      m
+    end
+    let ctx = TemplateContext(
+      recover Map[String, {(String): String}] end, partials)
+    let template = Template.parse(
+      "{{ include \"header\" }}\nbody\n{{ include \"footer\" }}", ctx)?
+    let values = TemplateValues
+    values("title") = "Page"
+    h.assert_eq[String]("==Page==\nbody\n--end--", template.render(values)?)
+
+
+class \nodoc\ iso _TestRenderIncludeWithBlocks is UnitTest
+  fun name(): String => "Render: include containing its own blocks"
+
+  fun apply(h: TestHelper)? =>
+    let partials = recover val
+      let m = Map[String, String]
+      m("list") =
+        "{{ if items }}{{ for i in items }}{{ i }},{{ end }}{{ else }}none{{ end }}"
+      m
+    end
+    let ctx = TemplateContext(
+      recover Map[String, {(String): String}] end, partials)
+    let template = Template.parse("Items: {{ include \"list\" }}", ctx)?
+
+    // With items
+    let v1 = TemplateValues
+    v1("items") = TemplateValue(
+      [TemplateValue("x"); TemplateValue("y")])
+    h.assert_eq[String]("Items: x,y,", template.render(v1)?)
+
+    // Without items (empty sequence)
+    let v2 = TemplateValues
+    v2("items") = TemplateValue(Array[TemplateValue])
+    h.assert_eq[String]("Items: none", template.render(v2)?)
 
 
 // ---------------------------------------------------------------------------

--- a/templates/parser.pony
+++ b/templates/parser.pony
@@ -10,6 +10,7 @@ primitive _TIf is Label fun text(): String => "If"
 primitive _TIfNot is Label fun text(): String => "IfNot"
 primitive _TElse is Label fun text(): String => "Else"
 primitive _TElseIf is Label fun text(): String => "ElseIf"
+primitive _TInclude is Label fun text(): String => "Include"
 
 primitive _EndNode
 primitive _ElseNode
@@ -48,6 +49,12 @@ class box _IfNotNode
   new box create(value': _PropNode) =>
     value = value'
 
+class box _IncludeNode
+  let name: String
+
+  new box create(name': String) =>
+    name = name'
+
 class box _LoopNode
   let target: String
   let source: _PropNode
@@ -59,7 +66,7 @@ class box _LoopNode
 type _StmtNode is
   ( _EndNode | _ElseNode | _ElseIfNode
   | _PropNode | _CallNode | _IfNode | _IfNotNode
-  | _LoopNode )
+  | _LoopNode | _IncludeNode )
 
 primitive _StmtParser
   fun _parser(): Parser val =>
@@ -82,7 +89,12 @@ primitive _StmtParser
       let else' = L("else").term(_TElse)
       let if' = (L("if") * prop).node(_TIf).hide(whitespace)
 
-      let stmt = ifnot / if' / loop / else_if / else' / end' / expr
+      let partial_char = alpha / digit / L("-")
+      let partial_name = (L("\"") * partial_char.many1() * L("\"")).term(_TName)
+      let include = (L("include") * partial_name).node(_TInclude)
+        .hide(whitespace)
+
+      let stmt = ifnot / if' / loop / include / else_if / else' / end' / expr
       stmt
     end
 
@@ -102,6 +114,7 @@ primitive _StmtParser
       | let _: _TEnd => _EndNode
       | let call: _TCall => _parse_call(ast as AST)?
       | let loop: _TLoop => _parse_loop(ast as AST)?
+      | let _: _TInclude => _parse_include(ast as AST)?
       | let prop: _TProp => _parse_prop(ast as AST)?
       else error
       end
@@ -126,6 +139,11 @@ primitive _StmtParser
     let target = (ast.children(1)? as Token).string()
     let source = _parse_prop(ast.children(3)? as AST)?
     _LoopNode(consume target, source)
+
+  fun _parse_include(ast: AST): _IncludeNode? =>
+    let quoted = (ast.children(1)? as Token).string()
+    let name = quoted.substring(1, -1)
+    _IncludeNode(consume name)
 
   fun _parse_prop(ast: AST): _PropNode? =>
     let name = (ast.children(0)? as Token).string()

--- a/templates/template.pony
+++ b/templates/template.pony
@@ -14,6 +14,9 @@ blocks. Supported block types:
 * **Loops**: `{{ for item in items }}...{{ end }}`
 * **Function calls**: `{{ fn(arg) }}` using functions registered via
   `TemplateContext`
+* **Includes**: `{{ include "name" }}` inlines a named partial registered via
+  `TemplateContext`. Partials share the same variable scope and can contain
+  any block type. Circular includes are detected at parse time.
 """
 
 use "collections"
@@ -176,12 +179,22 @@ class TemplateValues
 
 
 class TemplateContext
+  """
+  Configuration for template parsing. Provides named functions that can be
+  called from templates via `{{ fn(arg) }}`, and named partials that can be
+  inlined via `{{ include "name" }}`.
+  """
   let functions: Map[String, {(String): String}] box
+  let partials: Map[String, String] box
 
   new val create(
-    functions': Map[String, {(String): String}] val = recover Map[String, {(String): String}] end
+    functions': Map[String, {(String): String}] val
+      = recover Map[String, {(String): String}] end,
+    partials': Map[String, String] val
+      = recover Map[String, String] end
   ) =>
     functions = functions'
+    partials = partials'
 
 
 class val Template
@@ -202,7 +215,11 @@ class val Template
     else error
     end
 
-  fun tag _parse(source: String, ctx: TemplateContext val): Array[_Part] box? =>
+  fun tag _parse(
+    source: String,
+    ctx: TemplateContext val,
+    include_stack: Array[String] box = []
+  ): Array[_Part] box? =>
     var parts: Array[_Part] = []
     var current_parts = parts
     var open: Array[((_IfNode | _IfNotNode | _LoopNode | _IfElse), Array[_Part], Bool)] = []
@@ -237,6 +254,20 @@ class val Template
       | let loop: _LoopNode =>
         current_parts = Array[_Part]
         open.push((loop, current_parts, false))
+      | let inc: _IncludeNode =>
+        let partial_source = ctx.partials(inc.name)?
+        for name in include_stack.values() do
+          if name == inc.name then error end
+        end
+        let new_stack = Array[String](include_stack.size() + 1)
+        for name in include_stack.values() do
+          new_stack.push(name)
+        end
+        new_stack.push(inc.name)
+        let inline_parts = _parse(partial_source, ctx, new_stack)?
+        for p in inline_parts.values() do
+          current_parts.push(p)
+        end
       end
 
       prev_end = end_pos + 2


### PR DESCRIPTION
Partials let templates reuse shared fragments via `{{ include "name" }}`. Partial strings are registered in `TemplateContext` and inlined at parse time — the same resolution strategy used for functions. Circular includes are detected by threading an include stack through the recursive `_parse` calls.

Design: #38