### PR TITLE
Add template inheritance

### DIFF
--- a/.release-notes/add-template-inheritance.md
+++ b/.release-notes/add-template-inheritance.md
@@ -1,0 +1,24 @@
+## Add template inheritance
+
+Templates can now extend a base layout and override named blocks. A base template defines `{{ block name }}...{{ end }}` sections with default content. A child template declares `{{ extends "base" }}` as its first statement and overrides specific blocks — blocks not overridden render their defaults from the base.
+
+```pony
+let ctx = TemplateContext(
+  recover Map[String, {(String): String}] end,
+  recover val
+    let p = Map[String, String]
+    p("base") =
+      "<head>{{ block head }}<title>Default</title>{{ end }}</head>" +
+      "<body>{{ block content }}{{ end }}</body>"
+    p
+  end
+)
+
+let template = Template.parse(
+  "{{ extends \"base\" }}" +
+  "{{ block head }}<title>{{ title }}</title>{{ end }}" +
+  "{{ block content }}<h1>{{ title }}</h1>{{ end }}",
+  ctx)?
+```
+
+Base templates are registered as partials via `TemplateContext` — the same mechanism used by `include`. Multi-level inheritance works naturally (child extends parent extends grandparent). Content outside `{{ block }}` definitions in a child is silently ignored. Circular extends chains are detected at parse time.

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,3 +17,7 @@ Registers a custom function via `TemplateContext` and calls it from within a tem
 ## [include-example](include-example/)
 
 Registers named partials via `TemplateContext` and inlines them with `{{ include "name" }}`. Demonstrates reusing template fragments across templates, with partials sharing the same variable scope.
+
+## [inheritance-example](inheritance-example/)
+
+Defines a base HTML layout with `{{ block head }}` and `{{ block content }}` sections, then creates a child template that extends the base and overrides both blocks. Demonstrates template inheritance via `{{ extends "base" }}` and `{{ block name }}...{{ end }}`.

--- a/examples/inheritance-example/inheritance-example.pony
+++ b/examples/inheritance-example/inheritance-example.pony
@@ -1,0 +1,59 @@
+// This example demonstrates template inheritance: a child template extends a
+// base layout and overrides specific named blocks.
+
+// In your code this `use` statement would be:
+// use "templates"
+use "../../templates"
+
+use "collections"
+
+actor Main
+  new create(env: Env) =>
+    // The base layout is registered as a partial. It defines blocks with
+    // default content that child templates can override.
+    let ctx = TemplateContext(
+      recover Map[String, {(String): String}] end,
+      recover val
+        let p = Map[String, String]
+        p("base") =
+          "<html>\n" +
+          "<head>{{ block head }}<title>Default Title</title>{{ end }}</head>\n" +
+          "<body>\n" +
+          "{{ block content }}(no content){{ end }}\n" +
+          "</body>\n" +
+          "</html>"
+        p
+      end
+    )
+
+    // The child template declares {{ extends "base" }} as its first statement,
+    // then overrides specific blocks. The "head" block is overridden with a
+    // dynamic title; the "content" block is filled in. Content outside block
+    // definitions in the child is silently ignored.
+    let template =
+      try
+        Template.parse(
+          "{{ extends \"base\" }}" +
+          "{{ block head }}<title>{{ title }}</title>{{ end }}" +
+          "{{ block content }}" +
+          "<h1>{{ title }}</h1>\n" +
+          "<p>Welcome, {{ user }}!</p>" +
+          "{{ end }}",
+          ctx)?
+      else
+        env.err.print("Could not parse template :(")
+        env.exitcode(1)
+        return
+      end
+
+    let values = TemplateValues
+    values("title") = "My Page"
+    values("user") = "Alice"
+
+    try
+      env.out.print(template.render(values)?)
+    else
+      env.err.print("Could not render template :(")
+      env.exitcode(1)
+      return
+    end

--- a/templates/_test.pony
+++ b/templates/_test.pony
@@ -96,6 +96,30 @@ actor \nodoc\ Main is TestList
     test(_TestRenderMultipleIncludes)
     test(_TestRenderIncludeWithBlocks)
 
+    // Extends/block parser tests
+    test(Property1UnitTest[String](_PropValidExtendsParsesToExtendsNode))
+    test(Property1UnitTest[String](_PropValidBlockParsesToBlockNode))
+    test(_TestParserExtendsBlockNodeFields)
+    test(_TestParserExtendsBlockKeywordAmbiguity)
+
+    // Extends/block parse error tests
+    test(_TestParseErrorExtendsNotFirst)
+    test(_TestParseErrorExtendsMissingBase)
+    test(_TestParseErrorCircularExtends)
+    test(_TestParseErrorElseAfterBlock)
+    test(_TestParseErrorElseIfAfterBlock)
+    test(_TestParseErrorDuplicateBlock)
+
+    // Inheritance render tests
+    test(_TestRenderInheritanceBasic)
+    test(_TestRenderInheritanceMultipleBlocks)
+    test(_TestRenderInheritanceEmptyDefault)
+    test(_TestRenderInheritanceBlockInsideIf)
+    test(_TestRenderInheritanceMultiLevel)
+    test(_TestRenderInheritanceWithIncludes)
+    test(_TestRenderInheritanceBlockWithVariables)
+    test(_TestRenderBlocksWithoutExtends)
+
     // from_file test (Step 8)
     test(_TestFromFile)
 
@@ -145,6 +169,19 @@ primitive \nodoc\ _Generators
         if (s.size() >= 3) and s.at("if", 0) then
           try
             let c = s(2)?
+            if ((c >= 'a') and (c <= 'z'))
+              or ((c >= 'A') and (c <= 'Z'))
+              or (c == '_')
+            then
+              return (consume s, false)
+            end
+          end
+        end
+        // Reject names starting with "block" + alpha/underscore
+        // (parses as _BlockNode, same as "iffy" → _IfNode)
+        if (s.size() >= 6) and s.at("block", 0) then
+          try
+            let c = s(5)?
             if ((c >= 'a') and (c <= 'z'))
               or ((c >= 'A') and (c <= 'Z'))
               or (c == '_')
@@ -225,6 +262,31 @@ primitive \nodoc\ _Generators
           end
           "include \"" + consume name + "\""
       end)
+
+  fun valid_extends_stmt(): Generator[String] =>
+    """
+    Generates `extends "name"` where name matches `[a-zA-Z0-9_-]+`.
+    """
+    let chars: String val =
+      "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+    Generator[String](
+      object is GenObj[String]
+        fun generate(rnd: Randomness): String^ =>
+          let len = rnd.usize(1, 20)
+          let name = recover iso String(len) end
+          var i: USize = 0
+          while i < len do
+            try name.push(chars(rnd.usize(0, chars.size() - 1))?) end
+            i = i + 1
+          end
+          "extends \"" + consume name + "\""
+      end)
+
+  fun valid_block_stmt(): Generator[String] =>
+    """
+    Generates `block name` where name is a valid identifier.
+    """
+    valid_name().map[String]({(name) => "block " + name })
 
   fun invalid_stmt(): Generator[box->String] =>
     """
@@ -1583,6 +1645,381 @@ class \nodoc\ iso _TestRenderIncludeWithBlocks is UnitTest
     let v2 = TemplateValues
     v2("items") = TemplateValue(Array[TemplateValue])
     h.assert_eq[String]("Items: none", template.render(v2)?)
+
+
+// ---------------------------------------------------------------------------
+// Extends/block parser tests
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _PropValidExtendsParsesToExtendsNode is Property1[String]
+  fun name(): String => "Parser: valid extends parses to _ExtendsNode"
+
+  fun gen(): Generator[String] =>
+    _Generators.valid_extends_stmt()
+
+  fun ref property(stmt: String, h: PropertyHelper) ? =>
+    _StmtParser.parse(stmt)? as _ExtendsNode
+
+
+class \nodoc\ iso _PropValidBlockParsesToBlockNode is Property1[String]
+  fun name(): String => "Parser: valid block parses to _BlockNode"
+
+  fun gen(): Generator[String] =>
+    _Generators.valid_block_stmt()
+
+  fun ref property(stmt: String, h: PropertyHelper) ? =>
+    _StmtParser.parse(stmt)? as _BlockNode
+
+
+class \nodoc\ iso _TestParserExtendsBlockNodeFields is UnitTest
+  fun name(): String => "Parser: extends and block node field correctness"
+
+  fun apply(h: TestHelper)? =>
+    // extends "base" → _ExtendsNode(name="base")
+    match _StmtParser.parse("extends \"base\"")?
+    | let ext: _ExtendsNode =>
+      h.assert_eq[String]("base", ext.name)
+    else h.fail("expected _ExtendsNode"); error
+    end
+
+    // extends "my-layout" → name with hyphen
+    match _StmtParser.parse("extends \"my-layout\"")?
+    | let ext: _ExtendsNode =>
+      h.assert_eq[String]("my-layout", ext.name)
+    else h.fail("expected _ExtendsNode with hyphen"); error
+    end
+
+    // block content → _BlockNode(name="content")
+    match _StmtParser.parse("block content")?
+    | let blk: _BlockNode =>
+      h.assert_eq[String]("content", blk.name)
+    else h.fail("expected _BlockNode"); error
+    end
+
+    // block head → _BlockNode(name="head")
+    match _StmtParser.parse("block head")?
+    | let blk: _BlockNode =>
+      h.assert_eq[String]("head", blk.name)
+    else h.fail("expected _BlockNode"); error
+    end
+
+
+class \nodoc\ iso _TestParserExtendsBlockKeywordAmbiguity is UnitTest
+  fun name(): String => "Parser: extends/block keyword ambiguity"
+
+  fun apply(h: TestHelper) =>
+    // bare "extends" → _PropNode (no quoted string follows)
+    h.assert_no_error({() ? =>
+      _StmtParser.parse("extends")? as _PropNode
+    })
+
+    // "extendsfoo" → _PropNode (no space + quote)
+    h.assert_no_error({() ? =>
+      _StmtParser.parse("extendsfoo")? as _PropNode
+    })
+
+    // bare "block" → _PropNode (no space + name follows)
+    h.assert_no_error({() ? =>
+      _StmtParser.parse("block")? as _PropNode
+    })
+
+    // "blockfoo" → _BlockNode("foo") (like "iffy" → _IfNode)
+    h.assert_no_error({() ? =>
+      match _StmtParser.parse("blockfoo")?
+      | let blk: _BlockNode =>
+        if blk.name != "foo" then error end
+      else error
+      end
+    })
+
+
+// ---------------------------------------------------------------------------
+// Extends/block parse error tests
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _TestParseErrorExtendsNotFirst is UnitTest
+  fun name(): String => "Template parse error: extends not first statement"
+
+  fun apply(h: TestHelper) =>
+    // extends after a variable substitution
+    h.assert_error({() ? =>
+      let partials = recover val
+        let m = Map[String, String]
+        m("base") = "base content"
+        m
+      end
+      let ctx = TemplateContext(
+        recover Map[String, {(String): String}] end, partials)
+      Template.parse("{{ name }}{{ extends \"base\" }}", ctx)?
+    })
+
+    // extends after an if block
+    h.assert_error({() ? =>
+      let partials = recover val
+        let m = Map[String, String]
+        m("base") = "base content"
+        m
+      end
+      let ctx = TemplateContext(
+        recover Map[String, {(String): String}] end, partials)
+      Template.parse(
+        "{{ if x }}y{{ end }}{{ extends \"base\" }}", ctx)?
+    })
+
+
+class \nodoc\ iso _TestParseErrorExtendsMissingBase is UnitTest
+  fun name(): String => "Template parse error: extends references missing base"
+
+  fun apply(h: TestHelper) =>
+    h.assert_error({() ? =>
+      Template.parse("{{ extends \"nonexistent\" }}")?
+    })
+
+
+class \nodoc\ iso _TestParseErrorCircularExtends is UnitTest
+  fun name(): String => "Template parse error: circular extends"
+
+  fun apply(h: TestHelper) =>
+    // Self-extends
+    h.assert_error({() ? =>
+      let partials = recover val
+        let m = Map[String, String]
+        m("self") = "{{ extends \"self\" }}"
+        m
+      end
+      let ctx = TemplateContext(
+        recover Map[String, {(String): String}] end, partials)
+      Template.parse("{{ extends \"self\" }}", ctx)?
+    })
+
+    // Mutual cycle: a extends b, b extends a
+    h.assert_error({() ? =>
+      let partials = recover val
+        let m = Map[String, String]
+        m("a") = "{{ extends \"b\" }}"
+        m("b") = "{{ extends \"a\" }}"
+        m
+      end
+      let ctx = TemplateContext(
+        recover Map[String, {(String): String}] end, partials)
+      Template.parse("{{ extends \"a\" }}", ctx)?
+    })
+
+
+class \nodoc\ iso _TestParseErrorElseAfterBlock is UnitTest
+  fun name(): String => "Template parse error: else after block"
+
+  fun apply(h: TestHelper) =>
+    h.assert_error({() ? =>
+      Template.parse("{{ block content }}body{{ else }}alt{{ end }}")?
+    })
+
+
+class \nodoc\ iso _TestParseErrorElseIfAfterBlock is UnitTest
+  fun name(): String => "Template parse error: elseif after block"
+
+  fun apply(h: TestHelper) =>
+    h.assert_error({() ? =>
+      Template.parse(
+        "{{ block content }}body{{ elseif x }}alt{{ end }}")?
+    })
+
+
+class \nodoc\ iso _TestParseErrorDuplicateBlock is UnitTest
+  fun name(): String =>
+    "Template parse error: duplicate block names in child"
+
+  fun apply(h: TestHelper) =>
+    h.assert_error({() ? =>
+      let partials = recover val
+        let m = Map[String, String]
+        m("base") = "{{ block slot }}default{{ end }}"
+        m
+      end
+      let ctx = TemplateContext(
+        recover Map[String, {(String): String}] end, partials)
+      Template.parse(
+        "{{ extends \"base\" }}" +
+        "{{ block slot }}first{{ end }}" +
+        "{{ block slot }}second{{ end }}",
+        ctx)?
+    })
+
+
+// ---------------------------------------------------------------------------
+// Inheritance render tests
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _TestRenderInheritanceBasic is UnitTest
+  fun name(): String => "Render: basic inheritance overrides one block"
+
+  fun apply(h: TestHelper)? =>
+    let partials = recover val
+      let m = Map[String, String]
+      m("base") =
+        "<head>{{ block head }}default{{ end }}</head>" +
+        "<body>{{ block content }}{{ end }}</body>"
+      m
+    end
+    let ctx = TemplateContext(
+      recover Map[String, {(String): String}] end, partials)
+    let template = Template.parse(
+      "{{ extends \"base\" }}" +
+      "{{ block content }}Hello!{{ end }}",
+      ctx)?
+    let values = TemplateValues
+    h.assert_eq[String](
+      "<head>default</head><body>Hello!</body>",
+      template.render(values)?)
+
+
+class \nodoc\ iso _TestRenderInheritanceMultipleBlocks is UnitTest
+  fun name(): String =>
+    "Render: inheritance overrides subset of blocks"
+
+  fun apply(h: TestHelper)? =>
+    let partials = recover val
+      let m = Map[String, String]
+      m("base") =
+        "{{ block a }}A{{ end }}-{{ block b }}B{{ end }}" +
+        "-{{ block c }}C{{ end }}"
+      m
+    end
+    let ctx = TemplateContext(
+      recover Map[String, {(String): String}] end, partials)
+
+    // Override only 'a' and 'c', leave 'b' as default
+    let template = Template.parse(
+      "{{ extends \"base\" }}" +
+      "{{ block a }}X{{ end }}" +
+      "{{ block c }}Z{{ end }}",
+      ctx)?
+    h.assert_eq[String]("X-B-Z", template.render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestRenderInheritanceEmptyDefault is UnitTest
+  fun name(): String => "Render: block with empty default"
+
+  fun apply(h: TestHelper)? =>
+    let partials = recover val
+      let m = Map[String, String]
+      m("base") = "before{{ block slot }}{{ end }}after"
+      m
+    end
+    let ctx = TemplateContext(
+      recover Map[String, {(String): String}] end, partials)
+
+    // Without override — empty default
+    let t1 = Template.parse(
+      "{{ extends \"base\" }}", ctx)?
+    h.assert_eq[String]("beforeafter", t1.render(TemplateValues)?)
+
+    // With override — fills slot
+    let t2 = Template.parse(
+      "{{ extends \"base\" }}{{ block slot }}FILL{{ end }}", ctx)?
+    h.assert_eq[String]("beforeFILLafter", t2.render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestRenderInheritanceBlockInsideIf is UnitTest
+  fun name(): String => "Render: block inside if/for in base"
+
+  fun apply(h: TestHelper)? =>
+    let partials = recover val
+      let m = Map[String, String]
+      m("base") =
+        "{{ if show }}{{ block content }}default{{ end }}{{ end }}"
+      m
+    end
+    let ctx = TemplateContext(
+      recover Map[String, {(String): String}] end, partials)
+    let template = Template.parse(
+      "{{ extends \"base\" }}" +
+      "{{ block content }}overridden{{ end }}",
+      ctx)?
+
+    // show present → overridden block renders
+    let v1 = TemplateValues
+    v1("show") = "yes"
+    h.assert_eq[String]("overridden", template.render(v1)?)
+
+    // show absent → if body not rendered
+    h.assert_eq[String]("", template.render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestRenderInheritanceMultiLevel is UnitTest
+  fun name(): String => "Render: multi-level inheritance (3 levels)"
+
+  fun apply(h: TestHelper)? =>
+    let partials = recover val
+      let m = Map[String, String]
+      m("grandparent") =
+        "[{{ block title }}GP{{ end }}|{{ block body }}GP-body{{ end }}]"
+      m("parent") =
+        "{{ extends \"grandparent\" }}" +
+        "{{ block body }}P-body{{ end }}"
+      m
+    end
+    let ctx = TemplateContext(
+      recover Map[String, {(String): String}] end, partials)
+
+    // Child overrides title, parent already overrode body
+    let template = Template.parse(
+      "{{ extends \"parent\" }}" +
+      "{{ block title }}Child{{ end }}",
+      ctx)?
+    h.assert_eq[String]("[Child|P-body]", template.render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestRenderInheritanceWithIncludes is UnitTest
+  fun name(): String => "Render: inheritance combined with includes"
+
+  fun apply(h: TestHelper)? =>
+    let partials = recover val
+      let m = Map[String, String]
+      m("nav") = "[NAV]"
+      m("base") =
+        "{{ include \"nav\" }}{{ block content }}default{{ end }}"
+      m
+    end
+    let ctx = TemplateContext(
+      recover Map[String, {(String): String}] end, partials)
+    let template = Template.parse(
+      "{{ extends \"base\" }}" +
+      "{{ block content }}page{{ end }}",
+      ctx)?
+    h.assert_eq[String]("[NAV]page", template.render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestRenderInheritanceBlockWithVariables is UnitTest
+  fun name(): String => "Render: block overrides using template variables"
+
+  fun apply(h: TestHelper)? =>
+    let partials = recover val
+      let m = Map[String, String]
+      m("base") =
+        "<title>{{ block title }}Default{{ end }}</title>"
+      m
+    end
+    let ctx = TemplateContext(
+      recover Map[String, {(String): String}] end, partials)
+    let template = Template.parse(
+      "{{ extends \"base\" }}" +
+      "{{ block title }}{{ page_title }}{{ end }}",
+      ctx)?
+    let values = TemplateValues
+    values("page_title") = "My Page"
+    h.assert_eq[String]("<title>My Page</title>", template.render(values)?)
+
+
+class \nodoc\ iso _TestRenderBlocksWithoutExtends is UnitTest
+  fun name(): String =>
+    "Render: standalone template with blocks renders defaults"
+
+  fun apply(h: TestHelper)? =>
+    let template = Template.parse(
+      "before{{ block slot }}DEFAULT{{ end }}after")?
+    h.assert_eq[String](
+      "beforeDEFAULTafter", template.render(TemplateValues)?)
 
 
 // ---------------------------------------------------------------------------

--- a/templates/parser.pony
+++ b/templates/parser.pony
@@ -11,6 +11,8 @@ primitive _TIfNot is Label fun text(): String => "IfNot"
 primitive _TElse is Label fun text(): String => "Else"
 primitive _TElseIf is Label fun text(): String => "ElseIf"
 primitive _TInclude is Label fun text(): String => "Include"
+primitive _TExtends is Label fun text(): String => "Extends"
+primitive _TBlock is Label fun text(): String => "Block"
 
 primitive _EndNode
 primitive _ElseNode
@@ -63,10 +65,22 @@ class box _LoopNode
     target = target'
     source = source'
 
+class box _ExtendsNode
+  let name: String
+
+  new box create(name': String) =>
+    name = name'
+
+class box _BlockNode
+  let name: String
+
+  new box create(name': String) =>
+    name = name'
+
 type _StmtNode is
   ( _EndNode | _ElseNode | _ElseIfNode
   | _PropNode | _CallNode | _IfNode | _IfNotNode
-  | _LoopNode | _IncludeNode )
+  | _LoopNode | _IncludeNode | _ExtendsNode | _BlockNode )
 
 primitive _StmtParser
   fun _parser(): Parser val =>
@@ -93,8 +107,13 @@ primitive _StmtParser
       let partial_name = (L("\"") * partial_char.many1() * L("\"")).term(_TName)
       let include = (L("include") * partial_name).node(_TInclude)
         .hide(whitespace)
+      let extends' = (L("extends") * partial_name).node(_TExtends)
+        .hide(whitespace)
+      let block' = (L("block") * name).node(_TBlock).hide(whitespace)
 
-      let stmt = ifnot / if' / loop / include / else_if / else' / end' / expr
+      let stmt =
+        extends' / ifnot / if' / loop / include / block' / else_if
+          / else' / end' / expr
       stmt
     end
 
@@ -115,6 +134,8 @@ primitive _StmtParser
       | let call: _TCall => _parse_call(ast as AST)?
       | let loop: _TLoop => _parse_loop(ast as AST)?
       | let _: _TInclude => _parse_include(ast as AST)?
+      | let _: _TExtends => _parse_extends(ast as AST)?
+      | let _: _TBlock => _parse_block(ast as AST)?
       | let prop: _TProp => _parse_prop(ast as AST)?
       else error
       end
@@ -144,6 +165,15 @@ primitive _StmtParser
     let quoted = (ast.children(1)? as Token).string()
     let name = quoted.substring(1, -1)
     _IncludeNode(consume name)
+
+  fun _parse_extends(ast: AST): _ExtendsNode? =>
+    let quoted = (ast.children(1)? as Token).string()
+    let name = quoted.substring(1, -1)
+    _ExtendsNode(consume name)
+
+  fun _parse_block(ast: AST): _BlockNode? =>
+    let block_name = (ast.children(1)? as Token).string()
+    _BlockNode(consume block_name)
 
   fun _parse_prop(ast: AST): _PropNode? =>
     let name = (ast.children(0)? as Token).string()

--- a/templates/template.pony
+++ b/templates/template.pony
@@ -17,6 +17,13 @@ blocks. Supported block types:
 * **Includes**: `{{ include "name" }}` inlines a named partial registered via
   `TemplateContext`. Partials share the same variable scope and can contain
   any block type. Circular includes are detected at parse time.
+* **Template inheritance**: A child template declares
+  `{{ extends "base" }}` as its first statement and overrides named blocks
+  defined in the base with `{{ block name }}...{{ end }}`. Base templates are
+  registered as partials via `TemplateContext`. Blocks not overridden render
+  their default content from the base. Multi-level inheritance is supported.
+  Content outside `{{ block }}` definitions in a child template is silently
+  ignored. Circular extends chains are detected at parse time.
 """
 
 use "collections"
@@ -92,9 +99,17 @@ class _Loop
     source = source'
     body = body'
 
+class _Block
+  let name: String
+  let body: Array[_Part] box
+
+  new box create(name': String, body': Array[_Part] box) =>
+    name = name'
+    body = body'
+
 type _Part is
   ( (_Literal, String) | _Call box | _PropNode
-  | _If box | _IfNot box | _Loop box )
+  | _If box | _IfNot box | _Loop box | _Block box )
 
 
 class box TemplateValue
@@ -182,7 +197,8 @@ class TemplateContext
   """
   Configuration for template parsing. Provides named functions that can be
   called from templates via `{{ fn(arg) }}`, and named partials that can be
-  inlined via `{{ include "name" }}`.
+  inlined via `{{ include "name" }}` or used as base templates for
+  inheritance via `{{ extends "name" }}`.
   """
   let functions: Map[String, {(String): String}] box
   let partials: Map[String, String] box
@@ -201,7 +217,7 @@ class val Template
   let _parts: Array[_Part] box
 
   new val parse(source: String, ctx: TemplateContext val = TemplateContext())? =>
-    _parts = _parse(source, ctx)?
+    _parts = _parse_template(source, ctx)?
 
   new val from_file(path: FilePath, ctx: TemplateContext val = TemplateContext())? =>
     let chunk_size: USize = 1024 * 1024 * 1
@@ -211,7 +227,7 @@ class val Template
       while file.errno() is FileOK do
         data = data + file.read(chunk_size)
       end
-      _parts = _parse(data.string(), ctx)?
+      _parts = _parse_template(data.string(), ctx)?
     else error
     end
 
@@ -222,7 +238,8 @@ class val Template
   ): Array[_Part] box? =>
     var parts: Array[_Part] = []
     var current_parts = parts
-    var open: Array[((_IfNode | _IfNotNode | _LoopNode | _IfElse), Array[_Part], Bool)] = []
+    var open: Array[((_IfNode | _IfNotNode | _LoopNode | _IfElse | _BlockNode), Array[_Part], Bool)] = []
+    var first_stmt: Bool = true
     var prev_end: ISize = 0
     while prev_end < source.size().isize() do
       let start_pos =
@@ -268,8 +285,14 @@ class val Template
         for p in inline_parts.values() do
           current_parts.push(p)
         end
+      | let ext: _ExtendsNode =>
+        if not first_stmt then error end
+      | let blk: _BlockNode =>
+        current_parts = Array[_Part]
+        open.push((blk, current_parts, false))
       end
 
+      first_stmt = false
       prev_end = end_pos + 2
     end
 
@@ -282,7 +305,7 @@ class val Template
     consume parts
 
   fun tag _parse_end(
-    open: Array[((_IfNode | _IfNotNode | _LoopNode | _IfElse), Array[_Part], Bool)],
+    open: Array[((_IfNode | _IfNotNode | _LoopNode | _IfElse | _BlockNode), Array[_Part], Bool)],
     parts: Array[_Part]
   ): Array[_Part]? =>
     (let stmt, let body, _) = open.pop()?
@@ -296,6 +319,7 @@ class val Template
         else _If(ie.value, ie.if_body, body)
         end
       | let loop: _LoopNode => _Loop(loop.target, loop.source, body)
+      | let blk: _BlockNode => _Block(blk.name, body)
       end
 
     // Auto-close elseif chain entries
@@ -327,7 +351,7 @@ class val Template
     next_current
 
   fun tag _parse_else(
-    open: Array[((_IfNode | _IfNotNode | _LoopNode | _IfElse), Array[_Part], Bool)]
+    open: Array[((_IfNode | _IfNotNode | _LoopNode | _IfElse | _BlockNode), Array[_Part], Bool)]
   ): Array[_Part]? =>
     (let stmt, let if_body, _) = open.pop()?
     match stmt
@@ -345,7 +369,7 @@ class val Template
     end
 
   fun tag _parse_elseif_stmt(
-    open: Array[((_IfNode | _IfNotNode | _LoopNode | _IfElse), Array[_Part], Bool)],
+    open: Array[((_IfNode | _IfNotNode | _LoopNode | _IfElse | _BlockNode), Array[_Part], Bool)],
     else_if: _ElseIfNode
   ): Array[_Part]? =>
     (let stmt, let if_body, _) = open.pop()?
@@ -366,6 +390,107 @@ class val Template
     else
       error // elseif only valid inside an if or ifnot block
     end
+
+  fun tag _parse_template(
+    source: String,
+    ctx: TemplateContext val,
+    include_stack: Array[String] box = []
+  ): Array[_Part] box? =>
+    match _check_extends(source)?
+    | let base_name: String =>
+      for name in include_stack.values() do
+        if name == base_name then error end
+      end
+      let child_parts = _parse(source, ctx, include_stack)?
+      let overrides = _extract_blocks(child_parts)?
+      let base_source = ctx.partials(base_name)?
+      let new_stack = Array[String](include_stack.size() + 1)
+      for name in include_stack.values() do
+        new_stack.push(name)
+      end
+      new_stack.push(base_name)
+      _apply_overrides(_parse_template(base_source, ctx, new_stack)?, overrides)
+    else
+      _parse(source, ctx, include_stack)?
+    end
+
+  fun tag _check_extends(source: String): (String | None)? =>
+    let start_pos =
+      try source.find("{{")?
+      else return None
+      end
+    let end_pos =
+      try source.find("}}" where offset = start_pos)?
+      else return None
+      end
+    let stmt_source: String val = source.substring(start_pos + 2, end_pos)
+    match _StmtParser.parse(stmt_source)?
+    | let ext: _ExtendsNode => ext.name
+    else None
+    end
+
+  fun tag _extract_blocks(
+    parts: Array[_Part] box
+  ): Map[String, Array[_Part] box]? =>
+    let blocks = Map[String, Array[_Part] box]
+    for part in parts.values() do
+      match part
+      | let blk: _Block box =>
+        if blocks.contains(blk.name) then error end
+        blocks(blk.name) = blk.body
+      end
+    end
+    blocks
+
+  fun tag _apply_overrides(
+    parts: Array[_Part] box,
+    overrides: Map[String, Array[_Part] box] box
+  ): Array[_Part] box =>
+    let result = Array[_Part]
+    for part in parts.values() do
+      match part
+      | let blk: _Block box =>
+        try
+          let override_body = overrides(blk.name)?
+          for p in override_body.values() do
+            result.push(p)
+          end
+        else
+          result.push(
+            _Block(blk.name, _apply_overrides(blk.body, overrides)))
+        end
+      | let if': _If box =>
+        let new_else: (Array[_Part] box | None) =
+          match if'.else_body
+          | let eb: Array[_Part] box =>
+            _apply_overrides(eb, overrides)
+          else None
+          end
+        result.push(
+          _If(if'.value, _apply_overrides(if'.body, overrides), new_else))
+      | let ifnot: _IfNot box =>
+        let new_else: (Array[_Part] box | None) =
+          match ifnot.else_body
+          | let eb: Array[_Part] box =>
+            _apply_overrides(eb, overrides)
+          else None
+          end
+        result.push(
+          _IfNot(
+            ifnot.value,
+            _apply_overrides(ifnot.body, overrides),
+            new_else))
+      | let loop: _Loop box =>
+        result.push(
+          _Loop(
+            loop.target,
+            loop.source,
+            _apply_overrides(loop.body, overrides)))
+      else
+        result.push(part)
+      end
+    end
+    result
 
   fun render(values: TemplateValues box): String? =>
     """
@@ -420,6 +545,8 @@ class val Template
           let body_values = values._override(loop.target, value)
           result = result + _render_parts(loop.body, body_values)?
         end
+      | let blk: _Block box =>
+        result = result + _render_parts(blk.body, values)?
       end
     end
     result.string()


### PR DESCRIPTION
Child templates can declare `{{ extends "base" }}` as their first statement and override named `{{ block name }}...{{ end }}` sections defined in the base. Base templates are registered as partials via `TemplateContext`, the same mechanism used by includes.

Resolution happens at parse time: the child's block overrides are extracted, the base is parsed recursively (supporting multi-level inheritance), and overrides are applied by walking the base AST. Blocks not overridden render their default content. Circular extends chains are detected using the same stack as circular include detection.

Design: #38