### PR TITLE
Add default values for missing variables

### DIFF
--- a/.release-notes/add-default-values.md
+++ b/.release-notes/add-default-values.md
@@ -1,0 +1,28 @@
+## Add default values for missing variables
+
+Missing variables in templates render as empty strings, with no way to provide a fallback. `| default("...")` lets template authors declare what to show when a variable is absent.
+
+```pony
+let t = Template.parse(
+  "Hello {{ name | default(\"stranger\") }}")?
+
+// name is missing — renders "Hello stranger"
+t.render(TemplateValues)?
+
+// name is present — renders "Hello Alice"
+let v = TemplateValues
+v("name") = "Alice"
+t.render(v)?
+```
+
+Defaults work with dotted properties and function call arguments:
+
+```pony
+// Dotted property with default
+Template.parse("{{ user.name | default(\"anon\") }}")?
+
+// Function argument with default
+Template.parse("{{ upper(name | default(\"anon\")) }}", ctx)?
+```
+
+Defaults are not allowed in control flow conditions (`if`, `ifnot`, `elseif`, `for ... in`) — a default would make the condition always truthy, defeating its purpose.

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,10 @@ Each subdirectory is a self-contained Pony program demonstrating a different par
 
 Parses a template with a single placeholder, binds a value, and renders the result. Demonstrates the core workflow: `Template.parse()`, `TemplateValues`, and `Template.render()`. Start here if you're new to the library.
 
+## [default-values-example](default-values-example/)
+
+Uses `| default("...")` to provide fallback text when variables are missing. Shows the three cases: all values provided (defaults ignored), no values (defaults used), and partial values (mix of actual and default).
+
 ## [conditionals-example](conditionals-example/)
 
 Shows how to use `if`/`else`, `if`/`elseif`/`else`, and `ifnot` blocks to conditionally include content based on whether values are present or absent. Demonstrates simple two-branch conditionals, chained multi-branch selection, negated conditionals, and sequence truthiness (guarding a loop with `if` so it only renders when items are present).

--- a/examples/default-values-example/default-values-example.pony
+++ b/examples/default-values-example/default-values-example.pony
@@ -1,0 +1,39 @@
+// in your code this `use` statement would be:
+// use "templates"
+use "../../templates"
+
+actor Main
+  new create(env: Env) =>
+    let template =
+      try
+        Template.parse(
+          "Hello {{ name | default(\"stranger\") }}, " +
+          "welcome to {{ place | default(\"the world\") }}!")?
+      else
+        env.err.print("Could not parse template :(")
+        env.exitcode(1)
+        return
+      end
+
+    // With values provided — defaults are not used
+    let values = TemplateValues
+    values("name") = "Alice"
+    values("place") = "Ponyville"
+    try
+      env.out.print(template.render(values)?)
+      // Output: Hello Alice, welcome to Ponyville!
+    end
+
+    // With no values — defaults are used
+    try
+      env.out.print(template.render(TemplateValues)?)
+      // Output: Hello stranger, welcome to the world!
+    end
+
+    // With only some values — mix of actual and default
+    let partial = TemplateValues
+    partial("name") = "Bob"
+    try
+      env.out.print(template.render(partial)?)
+      // Output: Hello Bob, welcome to the world!
+    end

--- a/templates/_test.pony
+++ b/templates/_test.pony
@@ -120,6 +120,23 @@ actor \nodoc\ Main is TestList
     test(_TestRenderInheritanceBlockWithVariables)
     test(_TestRenderBlocksWithoutExtends)
 
+    // Default value parser tests
+    test(Property1UnitTest[String](_PropValidPropDefaultParsesToPropNode))
+    test(_TestParserDefaultNodeFields)
+    test(_TestParserDefaultInCall)
+    test(_TestParserDefaultNotInControlFlow)
+
+    // Default value render tests
+    test(Property1UnitTest[(String, String)](_PropDefaultWhenMissing))
+    test(Property1UnitTest[(String, String, String)](_PropDefaultWhenPresent))
+    test(_TestRenderDefaultBasic)
+    test(_TestRenderDefaultWithDottedProp)
+    test(_TestRenderDefaultInCall)
+    test(_TestRenderDefaultInsideLoop)
+    test(_TestRenderDefaultInsideIf)
+    test(_TestCallArgMissingNoDefault)
+    test(_TestRenderDefaultWithBraces)
+
     // from_file test (Step 8)
     test(_TestFromFile)
 
@@ -288,6 +305,40 @@ primitive \nodoc\ _Generators
     """
     valid_name().map[String]({(name) => "block " + name })
 
+  fun default_value_string(): Generator[String] =>
+    """
+    Generates printable ASCII strings excluding `"`, length 0-30, for use
+    as default values in `| default("...")`. Braces are allowed because the
+    parser uses quote-aware delimiter scanning.
+    """
+    // Printable ASCII: space (0x20) through ~ (0x7E), excluding " (0x22)
+    let chars: String val =
+      " !#$%&'()*+,-./0123456789:;<=>?@"
+      + "ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`"
+      + "abcdefghijklmnopqrstuvwxyz{|}~"
+    Generator[String](
+      object is GenObj[String]
+        fun generate(rnd: Randomness): String^ =>
+          let len = rnd.usize(0, 30)
+          let s = recover iso String(len) end
+          var i: USize = 0
+          while i < len do
+            try s.push(chars(rnd.usize(0, chars.size() - 1))?) end
+            i = i + 1
+          end
+          consume s
+      end)
+
+  fun valid_prop_default_stmt(): Generator[String] =>
+    """
+    Generates `prop | default("value")` — a property with a default value.
+    """
+    Generators.map2[String, String, String](
+      valid_prop_stmt(), default_value_string(),
+      {(prop, default_val) =>
+        prop + " | default(\"" + default_val + "\")"
+      })
+
   fun invalid_stmt(): Generator[box->String] =>
     """
     Generates invalid statement strings, one per distinct failure mode.
@@ -306,6 +357,10 @@ primitive \nodoc\ _Generators
       "end."       // trailing dot after end
       "include \"\"" // empty include name
       "include \""   // unclosed quote
+      "foo | "          // incomplete default
+      "foo | default"   // missing parens
+      "foo | default()" // missing quotes
+      "foo | default(x)" // unquoted value
     ])
 
   fun literal_text(): Generator[String] =>
@@ -2020,6 +2075,321 @@ class \nodoc\ iso _TestRenderBlocksWithoutExtends is UnitTest
       "before{{ block slot }}DEFAULT{{ end }}after")?
     h.assert_eq[String](
       "beforeDEFAULTafter", template.render(TemplateValues)?)
+
+
+// ---------------------------------------------------------------------------
+// Default value parser tests
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _PropValidPropDefaultParsesToPropNode is Property1[String]
+  fun name(): String =>
+    "Parser: valid prop default parses to _PropNode"
+
+  fun gen(): Generator[String] =>
+    _Generators.valid_prop_default_stmt()
+
+  fun ref property(stmt: String, h: PropertyHelper) ? =>
+    let node = _StmtParser.parse(stmt)? as _PropNode
+    node.default_value as String
+
+
+class \nodoc\ iso _TestParserDefaultNodeFields is UnitTest
+  fun name(): String => "Parser: default value node field correctness"
+
+  fun apply(h: TestHelper)? =>
+    // name | default("hello") → _PropNode with default_value = "hello"
+    match _StmtParser.parse("name | default(\"hello\")")?
+    | let p: _PropNode =>
+      h.assert_eq[String]("name", p.name)
+      h.assert_eq[USize](0, p.props.size())
+      h.assert_eq[String]("hello", p.default_value as String)
+    else h.fail("expected _PropNode"); error
+    end
+
+    // a.b | default("x") → dotted prop with default
+    match _StmtParser.parse("a.b | default(\"x\")")?
+    | let p: _PropNode =>
+      h.assert_eq[String]("a", p.name)
+      h.assert_eq[USize](1, p.props.size())
+      h.assert_eq[String]("b", p.props(0)?)
+      h.assert_eq[String]("x", p.default_value as String)
+    else h.fail("expected _PropNode with dotted prop"); error
+    end
+
+    // a | default("") → empty default
+    match _StmtParser.parse("a | default(\"\")")?
+    | let p: _PropNode =>
+      h.assert_eq[String]("a", p.name)
+      h.assert_eq[String]("", p.default_value as String)
+    else h.fail("expected _PropNode with empty default"); error
+    end
+
+    // Plain "foo" → no default (default_value is None)
+    match _StmtParser.parse("foo")?
+    | let p: _PropNode =>
+      h.assert_eq[String]("foo", p.name)
+      match p.default_value
+      | let _: None => None
+      else h.fail("expected None default_value for plain prop"); error
+      end
+    else h.fail("expected _PropNode"); error
+    end
+
+
+class \nodoc\ iso _TestParserDefaultInCall is UnitTest
+  fun name(): String => "Parser: default value inside function call"
+
+  fun apply(h: TestHelper)? =>
+    // fn(name | default("x")) → _CallNode with defaulted arg
+    let ctx = TemplateContext(
+      recover
+        let functions = Map[String, {(String): String}]
+        functions("fn") = {(s) => s}
+        functions
+      end
+    )
+
+    match _StmtParser.parse("fn(name | default(\"x\"))")?
+    | let c: _CallNode =>
+      h.assert_eq[String]("fn", c.name)
+      h.assert_eq[String]("name", c.arg.name)
+      h.assert_eq[String]("x", c.arg.default_value as String)
+    else h.fail("expected _CallNode"); error
+    end
+
+    // fn(name) → still works, no default
+    match _StmtParser.parse("fn(name)")?
+    | let c: _CallNode =>
+      h.assert_eq[String]("fn", c.name)
+      h.assert_eq[String]("name", c.arg.name)
+      match c.arg.default_value
+      | let _: None => None
+      else h.fail("expected None default for plain call arg"); error
+      end
+    else h.fail("expected _CallNode"); error
+    end
+
+
+class \nodoc\ iso _TestParserDefaultNotInControlFlow is UnitTest
+  fun name(): String =>
+    "Parser: default value not allowed in control flow"
+
+  fun apply(h: TestHelper) =>
+    // if name | default("x") → should fail
+    h.assert_error({() ? =>
+      _StmtParser.parse("if name | default(\"x\")")?
+    })
+
+    // ifnot name | default("x") → should fail
+    h.assert_error({() ? =>
+      _StmtParser.parse("ifnot name | default(\"x\")")?
+    })
+
+    // for x in items | default("x") → should fail
+    h.assert_error({() ? =>
+      _StmtParser.parse("for x in items | default(\"x\")")?
+    })
+
+    // elseif name | default("x") → should fail
+    h.assert_error({() ? =>
+      _StmtParser.parse("elseif name | default(\"x\")")?
+    })
+
+
+// ---------------------------------------------------------------------------
+// Default value render tests
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _PropDefaultWhenMissing
+  is Property1[(String, String)]
+  fun name(): String =>
+    "Render: missing variable renders default value"
+
+  fun gen(): Generator[(String, String)] =>
+    Generators.zip2[String, String](
+      _Generators.valid_name(),
+      _Generators.default_value_string())
+
+  fun ref property(sample: (String, String), h: PropertyHelper) ? =>
+    (let n, let default_val) = sample
+    let source: String val =
+      "{{ " + n + " | default(\"" + default_val + "\") }}"
+    let template = Template.parse(source)?
+    h.assert_eq[String](default_val, template.render(TemplateValues)?)
+
+
+class \nodoc\ iso _PropDefaultWhenPresent
+  is Property1[(String, String, String)]
+  fun name(): String =>
+    "Render: present variable ignores default value"
+
+  fun gen(): Generator[(String, String, String)] =>
+    Generators.zip3[String, String, String](
+      _Generators.valid_name(),
+      _Generators.template_value_string(),
+      _Generators.default_value_string())
+
+  fun ref property(
+    sample: (String, String, String),
+    h: PropertyHelper)
+  ? =>
+    (let n, let actual_val, let default_val) = sample
+    let source: String val =
+      "{{ " + n + " | default(\"" + default_val + "\") }}"
+    let template = Template.parse(source)?
+    let values = TemplateValues
+    values(n) = actual_val
+    h.assert_eq[String](actual_val, template.render(values)?)
+
+
+class \nodoc\ iso _TestRenderDefaultBasic is UnitTest
+  fun name(): String => "Render: default value basic cases"
+
+  fun apply(h: TestHelper)? =>
+    // Variable present → actual value, default ignored
+    let t1 = Template.parse("{{ name | default(\"fallback\") }}")?
+    let v1 = TemplateValues
+    v1("name") = "Alice"
+    h.assert_eq[String]("Alice", t1.render(v1)?)
+
+    // Variable missing → default used
+    h.assert_eq[String]("fallback", t1.render(TemplateValues)?)
+
+    // Empty default string
+    let t2 = Template.parse("{{ name | default(\"\") }}")?
+    h.assert_eq[String]("", t2.render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestRenderDefaultWithDottedProp is UnitTest
+  fun name(): String =>
+    "Render: default value with dotted property"
+
+  fun apply(h: TestHelper)? =>
+    let template = Template.parse(
+      "{{ user.name | default(\"anon\") }}")?
+
+    // Dotted prop present → actual value
+    let v1 = TemplateValues
+    let user_props = Map[String, TemplateValue]
+    user_props("name") = TemplateValue("Alice")
+    v1("user") = TemplateValue("u", user_props)
+    h.assert_eq[String]("Alice", template.render(v1)?)
+
+    // Top-level name missing → default
+    h.assert_eq[String]("anon", template.render(TemplateValues)?)
+
+    // Top-level present but nested prop missing → default
+    let v2 = TemplateValues
+    v2("user") = TemplateValue("u")
+    h.assert_eq[String]("anon", template.render(v2)?)
+
+
+class \nodoc\ iso _TestRenderDefaultInCall is UnitTest
+  fun name(): String =>
+    "Render: default value in function call argument"
+
+  fun apply(h: TestHelper)? =>
+    let ctx = TemplateContext(
+      recover
+        let functions = Map[String, {(String): String}]
+        functions("upper") = {(s) =>
+          let out = s.clone()
+          out.upper_in_place()
+          consume out
+        }
+        functions
+      end
+    )
+
+    let template = Template.parse(
+      "{{ upper(name | default(\"anon\")) }}", ctx)?
+
+    // Variable present → function applied to actual value
+    let v1 = TemplateValues
+    v1("name") = "alice"
+    h.assert_eq[String]("ALICE", template.render(v1)?)
+
+    // Variable missing → function applied to default
+    h.assert_eq[String]("ANON", template.render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestRenderDefaultInsideLoop is UnitTest
+  fun name(): String => "Render: default value inside loop body"
+
+  fun apply(h: TestHelper)? =>
+    let values = TemplateValues
+
+    let item1_props = Map[String, TemplateValue]
+    item1_props("label") = TemplateValue("tagged")
+    let item2_props = Map[String, TemplateValue]
+
+    values("items") = TemplateValue(
+      [TemplateValue("A", item1_props)
+       TemplateValue("B", item2_props)])
+
+    let template = Template.parse(
+      "{{ for x in items }}" +
+      "{{ x.label | default(\"none\") }}," +
+      "{{ end }}")?
+    h.assert_eq[String]("tagged,none,", template.render(values)?)
+
+
+class \nodoc\ iso _TestRenderDefaultInsideIf is UnitTest
+  fun name(): String =>
+    "Render: default value in body of conditional"
+
+  fun apply(h: TestHelper)? =>
+    let template = Template.parse(
+      "{{ if show }}{{ title | default(\"Untitled\") }}{{ end }}")?
+
+    // show present, title present
+    let v1 = TemplateValues
+    v1("show") = "yes"
+    v1("title") = "My Page"
+    h.assert_eq[String]("My Page", template.render(v1)?)
+
+    // show present, title missing → default used
+    let v2 = TemplateValues
+    v2("show") = "yes"
+    h.assert_eq[String]("Untitled", template.render(v2)?)
+
+    // show absent → body not rendered at all
+    h.assert_eq[String]("", template.render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestCallArgMissingNoDefault is UnitTest
+  fun name(): String =>
+    "Call: missing argument without default still errors"
+
+  fun apply(h: TestHelper) =>
+    let ctx = TemplateContext(
+      recover
+        let functions = Map[String, {(String): String}]
+        functions("f") = {(s) => s}
+        functions
+      end
+    )
+    h.assert_error({() ? =>
+      let template = Template.parse("{{ f(missing) }}", ctx)?
+      template.render(TemplateValues)?
+    })
+
+
+class \nodoc\ iso _TestRenderDefaultWithBraces is UnitTest
+  fun name(): String =>
+    "Render: default value containing braces"
+
+  fun apply(h: TestHelper) ? =>
+    let values = TemplateValues
+
+    h.assert_eq[String]("a}b",
+      Template.parse("{{ x | default(\"a}b\") }}")?.render(values)?)
+    h.assert_eq[String]("a}}b",
+      Template.parse("{{ x | default(\"a}}b\") }}")?.render(values)?)
+    h.assert_eq[String]("a{b",
+      Template.parse("{{ x | default(\"a{b\") }}")?.render(values)?)
+    h.assert_eq[String]("a{{b",
+      Template.parse("{{ x | default(\"a{{b\") }}")?.render(values)?)
 
 
 // ---------------------------------------------------------------------------

--- a/templates/parser.pony
+++ b/templates/parser.pony
@@ -13,6 +13,7 @@ primitive _TElseIf is Label fun text(): String => "ElseIf"
 primitive _TInclude is Label fun text(): String => "Include"
 primitive _TExtends is Label fun text(): String => "Extends"
 primitive _TBlock is Label fun text(): String => "Block"
+primitive _TPropDefault is Label fun text(): String => "PropDefault"
 
 primitive _EndNode
 primitive _ElseNode
@@ -26,10 +27,16 @@ class box _ElseIfNode
 class box _PropNode
   let name: String
   let props: Array[String]
+  let default_value: (String | None)
 
-  new box create(name': String, props': Array[String]) =>
+  new box create(
+    name': String,
+    props': Array[String],
+    default_value': (String | None) = None
+  ) =>
     name = name'
     props = props'
+    default_value = default_value'
 
 class box _CallNode
   let name: String
@@ -92,10 +99,22 @@ primitive _StmtParser
       let name = (alpha * (alpha / digit).many()).term(_TName)
 
       let prop = (name * (L(".") * name).many()).node(_TProp)
-      let call = (name * L("(") * expr * L(")")).node(_TCall)
-      expr() = call / prop
 
       let whitespace = (L(" ") / L("\t")).many1()
+
+      // Default value: | default("...") with printable ASCII except "
+      // Wrap prop in a Forward to prevent Sequence.concat from flattening
+      // prop's internals when used as the left operand of `*`.
+      let prop_ref = Forward
+      prop_ref() = prop
+      let default_char = R(' ', '!') / R('#', '~')
+      let default_value = (L("\"") * default_char.many() * L("\"")).term(_TName)
+      let prop_with_default =
+        (prop_ref * L("|") * L("default") * L("(") * default_value * L(")"))
+          .node(_TPropDefault).hide(whitespace)
+
+      let call = (name * L("(") * expr * L(")")).node(_TCall)
+      expr() = call / prop_with_default / prop
       let end' = L("end").term(_TEnd)
       let loop = (L("for") * name * L("in") * prop).node(_TLoop).hide(whitespace)
       let ifnot = (L("ifnot") * prop).node(_TIfNot).hide(whitespace)
@@ -136,6 +155,7 @@ primitive _StmtParser
       | let _: _TInclude => _parse_include(ast as AST)?
       | let _: _TExtends => _parse_extends(ast as AST)?
       | let _: _TBlock => _parse_block(ast as AST)?
+      | let _: _TPropDefault => _parse_prop_default(ast as AST)?
       | let prop: _TProp => _parse_prop(ast as AST)?
       else error
       end
@@ -144,7 +164,11 @@ primitive _StmtParser
 
   fun _parse_call(ast: AST): _CallNode? =>
     let name = (ast.children(0)? as Token).string()
-    let arg = _parse_prop(ast.children(2)? as AST)?
+    let arg_ast = ast.children(2)? as AST
+    let arg = match arg_ast.label()
+    | let _: _TPropDefault => _parse_prop_default(arg_ast)?
+    else _parse_prop(arg_ast)?
+    end
     _CallNode(consume name, arg)
 
   fun _parse_if(ast: AST): _IfNode? =>
@@ -182,3 +206,13 @@ primitive _StmtParser
       props.push(((child as AST).children(1)? as Token).string())
     end
     _PropNode(consume name, props)
+
+  fun _parse_prop_default(ast: AST): _PropNode? =>
+    let prop = _parse_prop(ast.children(0)? as AST)?
+    let quoted = (ast.children(4)? as Token).string()
+    let default_str = quoted.substring(1, -1)
+    let props = Array[String](prop.props.size())
+    for p in prop.props.values() do
+      props.push(p)
+    end
+    _PropNode(prop.name, props, consume default_str)

--- a/templates/template.pony
+++ b/templates/template.pony
@@ -17,6 +17,11 @@ blocks. Supported block types:
 * **Includes**: `{{ include "name" }}` inlines a named partial registered via
   `TemplateContext`. Partials share the same variable scope and can contain
   any block type. Circular includes are detected at parse time.
+* **Default values**: `{{ name | default("fallback") }}` renders the fallback
+  string when the variable is missing. The value must be double-quoted; single
+  quotes are not supported. Works with dotted properties
+  (`{{ user.name | default("anon") }}`) and function arguments
+  (`{{ upper(name | default("anon")) }}`).
 * **Template inheritance**: A child template declares
   `{{ extends "base" }}` as its first statement and overrides named blocks
   defined in the base with `{{ block name }}...{{ end }}`. Base templates are
@@ -246,7 +251,7 @@ class val Template
         try source.find("{{" where offset = prev_end)?
         else break end
       let end_pos =
-        try source.find("}}" where offset = start_pos)?
+        try _find_close_delim(source, start_pos + 2)?
         else break end
       if start_pos != prev_end then
         let literal = source.substring(prev_end.isize(), start_pos)
@@ -420,7 +425,7 @@ class val Template
       else return None
       end
     let end_pos =
-      try source.find("}}" where offset = start_pos)?
+      try _find_close_delim(source, start_pos + 2)?
       else return None
       end
     let stmt_source: String val = source.substring(start_pos + 2, end_pos)
@@ -492,6 +497,31 @@ class val Template
     end
     result
 
+  fun tag _find_close_delim(source: String, from: ISize): ISize? =>
+    """
+    Find the closing `}}` delimiter starting from `from`, skipping over
+    double-quoted strings so that `}}` inside a default value like
+    `default("a}}b")` is not treated as the closing delimiter.
+    """
+    var i = from
+    let limit = source.size().isize()
+    while i < (limit - 1) do
+      if source(i.usize())? == '"' then
+        // Skip to closing quote
+        i = i + 1
+        while i < limit do
+          if source(i.usize())? == '"' then break end
+          i = i + 1
+        end
+      elseif
+        (source(i.usize())? == '}') and (source((i + 1).usize())? == '}')
+      then
+        return i
+      end
+      i = i + 1
+    end
+    error
+
   fun render(values: TemplateValues box): String? =>
     """
     Fills in the given values into template.
@@ -504,11 +534,22 @@ class val Template
       match part
       | (_Literal, let value: String) => result = result + value
       | let call: _Call box =>
-        let arg = values._lookup(call.arg)?
-        result = result + call.f(arg.string()?)
+        let arg_value = try values._lookup(call.arg)?.string()?
+        else
+          match call.arg.default_value
+          | let d: String => d
+          else error
+          end
+        end
+        result = result + call.f(arg_value)
       | let prop: _PropNode =>
-        // XXX make this an error instead
-        let substitution = try values._lookup(prop)?.string()? else "" end
+        let substitution = try values._lookup(prop)?.string()?
+        else
+          match prop.default_value
+          | let d: String => d
+          else ""
+          end
+        end
         result = result + substitution
       | let if': _If box =>
         if


### PR DESCRIPTION
Missing variables in templates silently render as empty strings, with no way for template authors to specify a fallback. This adds `| default("...")` syntax on variable references in substitution and function call argument positions, so templates can declare what to show when a variable is absent.

Defaults are structurally excluded from control flow conditions (`if`, `ifnot`, `elseif`, `for...in`) at the grammar level — a default would make the condition always truthy, defeating its purpose.

Design: #38