### PR TITLE
Add trim syntax for whitespace control

### DIFF
--- a/.release-notes/add-trim-syntax.md
+++ b/.release-notes/add-trim-syntax.md
@@ -1,0 +1,32 @@
+## Add trim syntax for whitespace control
+
+Templates now support `{{-` and `-}}` trim markers that strip whitespace from adjacent literals. `{{-` removes trailing whitespace (spaces, tabs, newlines) from the text before the tag, `-}}` removes leading whitespace from the text after it. Use both together with `{{- ... -}}` to strip in both directions.
+
+This matters most when generating indentation-sensitive output like YAML or Python. Without trimming, control flow tags (`if`, `for`, `end`) inject blank lines and leading whitespace into the output because the newlines around the tags themselves become part of the rendered text. Trim markers let you eliminate that whitespace without cramming everything onto one line.
+
+```pony
+let values = TemplateValues
+values("name") = "app"
+values("services") = TemplateValue(
+  recover val
+    let s = Array[TemplateValue]
+    s.push(TemplateValue("web"))
+    s.push(TemplateValue("db"))
+    s
+  end)
+
+let t = Template.parse(
+  "name: {{ name }}\n" +
+  "services:\n" +
+  "{{ for svc in services -}}" +
+  "\n- {{ svc }}\n" +
+  "{{ end }}")?
+
+t.render(values)?
+// name: app
+// services:
+// - web
+// - db
+```
+
+The right-trim on the `for` tag strips the newline that would otherwise appear before the first list item. Either marker can be used independently — you pick which side to trim based on where the unwanted whitespace is.

--- a/README.md
+++ b/README.md
@@ -58,3 +58,8 @@ As templates gets used in more projects, we expect to find and fix bugs. We also
   `TemplateContext`. Partials share the same variable scope as the surrounding
   template and can contain any block type. Circular includes are detected at
   parse time.
+* Whitespace trimming: `{{- x }}` strips trailing whitespace from the
+  preceding literal, `{{ x -}}` strips leading whitespace from the following
+  literal, `{{- x -}}` strips both. Useful for generating
+  indentation-sensitive output (YAML, Python, Pony) without unwanted blank
+  lines from control flow tags.

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,3 +25,7 @@ Registers named partials via `TemplateContext` and inlines them with `{{ include
 ## [inheritance-example](inheritance-example/)
 
 Defines a base HTML layout with `{{ block head }}` and `{{ block content }}` sections, then creates a child template that extends the base and overrides both blocks. Demonstrates template inheritance via `{{ extends "base" }}` and `{{ block name }}...{{ end }}`.
+
+## [trim-example](trim-example/)
+
+Uses `{{-` and `-}}` trim markers to strip whitespace around tags. Shows how selective trimming produces clean, indentation-sensitive output (like YAML service lists) without unwanted blank lines from control flow tags.

--- a/examples/trim-example/trim-example.pony
+++ b/examples/trim-example/trim-example.pony
@@ -1,0 +1,64 @@
+// This example demonstrates whitespace trimming with {{- and -}} markers.
+// Trim markers strip adjacent whitespace from literals, which is useful for
+// generating indentation-sensitive output without blank lines from control
+// flow tags.
+
+// In your code this `use` statement would be:
+// use "templates"
+use "../../templates"
+
+use "collections"
+
+actor Main
+  new create(env: Env) =>
+    // Without trimming, a loop injects extra whitespace from the for/end
+    // lines. With selective trim markers, we get clean output.
+    let values = TemplateValues
+    values("services") = TemplateValue(
+      recover val
+        let s = Array[TemplateValue]
+        s.push(TemplateValue("web"))
+        s.push(TemplateValue("db"))
+        s.push(TemplateValue("cache"))
+        s
+      end)
+
+    // Right-trim on the for tag strips the newline before loop body content.
+    // The end tag has no trim markers, so each iteration's trailing newline
+    // is preserved.
+    let template =
+      try
+        Template.parse(
+          "services:\n" +
+          "{{ for svc in services -}}" +
+          "\n- {{ svc }}\n" +
+          "{{ end }}")?
+      else
+        env.err.print("Could not parse template :(")
+        env.exitcode(1)
+        return
+      end
+
+    try
+      env.out.print(template.render(values)?)
+    else
+      env.err.print("Could not render template :(")
+      env.exitcode(1)
+      return
+    end
+
+    // Both-side trim to collapse whitespace completely
+    let inline_template =
+      try
+        Template.parse(
+          "items: {{- for svc in services -}} [{{ svc }}] {{- end }}",
+          TemplateContext)?
+      else
+        env.err.print("Could not parse template :(")
+        env.exitcode(1)
+        return
+      end
+
+    try
+      env.out.print(inline_template.render(values)?)
+    end

--- a/templates/_test.pony
+++ b/templates/_test.pony
@@ -137,6 +137,20 @@ actor \nodoc\ Main is TestList
     test(_TestCallArgMissingNoDefault)
     test(_TestRenderDefaultWithBraces)
 
+    // Trim syntax tests
+    test(_TestTrimLeftOnly)
+    test(_TestTrimRightOnly)
+    test(_TestTrimBoth)
+    test(_TestTrimWithIf)
+    test(_TestTrimWithFor)
+    test(_TestTrimWithInclude)
+    test(_TestTrimWithExtends)
+    test(_TestTrimAdjacentTags)
+    test(_TestTrimAtStart)
+    test(_TestTrimAtEnd)
+    test(_TestTrimProducesEmptyLiteral)
+    test(Property1UnitTest[String](_PropTrimDeterminism))
+
     // from_file test (Step 8)
     test(_TestFromFile)
 
@@ -2390,6 +2404,190 @@ class \nodoc\ iso _TestRenderDefaultWithBraces is UnitTest
       Template.parse("{{ x | default(\"a{b\") }}")?.render(values)?)
     h.assert_eq[String]("a{{b",
       Template.parse("{{ x | default(\"a{{b\") }}")?.render(values)?)
+
+
+// ---------------------------------------------------------------------------
+// Trim syntax tests
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _TestTrimLeftOnly is UnitTest
+  fun name(): String => "Trim: left trim strips trailing whitespace"
+
+  fun apply(h: TestHelper)? =>
+    let values = TemplateValues
+    values("x") = "world"
+    // {{- strips trailing whitespace (spaces) from preceding literal
+    h.assert_eq[String]("helloworld",
+      Template.parse("hello   {{- x }}")?.render(values)?)
+    // Strips newlines and tabs too
+    h.assert_eq[String]("helloworld",
+      Template.parse("hello\n\t {{- x }}")?.render(values)?)
+
+
+class \nodoc\ iso _TestTrimRightOnly is UnitTest
+  fun name(): String => "Trim: right trim strips leading whitespace"
+
+  fun apply(h: TestHelper)? =>
+    let values = TemplateValues
+    values("x") = "hello"
+    // -}} strips leading whitespace from following literal
+    h.assert_eq[String]("helloworld",
+      Template.parse("{{ x -}}   world")?.render(values)?)
+    // Strips newlines and tabs too
+    h.assert_eq[String]("helloworld",
+      Template.parse("{{ x -}}\n\t world")?.render(values)?)
+
+
+class \nodoc\ iso _TestTrimBoth is UnitTest
+  fun name(): String => "Trim: both trims on same tag"
+
+  fun apply(h: TestHelper)? =>
+    let values = TemplateValues
+    values("x") = "middle"
+    h.assert_eq[String]("leftmiddleright",
+      Template.parse("left   {{- x -}}   right")?.render(values)?)
+
+
+class \nodoc\ iso _TestTrimWithIf is UnitTest
+  fun name(): String => "Trim: with if/end blocks"
+
+  fun apply(h: TestHelper)? =>
+    let values = TemplateValues
+    values("show") = "yes"
+    // Trim around if/end strips all adjacent whitespace
+    h.assert_eq[String]("beforecontentafter",
+      Template.parse(
+        "before\n{{- if show -}}\ncontent\n{{- end -}}\nafter")?
+        .render(values)?)
+    // Selective trim: only right-trim on if, only left-trim on end
+    // keeps content whitespace intact
+    h.assert_eq[String]("before\ncontent\nafter",
+      Template.parse(
+        "before\n{{ if show -}}\ncontent\n{{- end }}\nafter")?
+        .render(values)?)
+
+
+class \nodoc\ iso _TestTrimWithFor is UnitTest
+  fun name(): String => "Trim: with for loop"
+
+  fun apply(h: TestHelper)? =>
+    let values = TemplateValues
+    values("items") = TemplateValue(
+      recover val
+        let s = Array[TemplateValue]
+        s.push(TemplateValue("a"))
+        s.push(TemplateValue("b"))
+        s.push(TemplateValue("c"))
+        s
+      end)
+    // Right-trim on for and left-trim on end to avoid blank lines
+    // around loop body. Each iteration produces "- <item>\n".
+    h.assert_eq[String]("items:\n- a\n- b\n- c\n",
+      Template.parse(
+        "items:\n{{ for item in items -}}\n- {{ item }}\n{{ end }}")?
+        .render(values)?)
+
+
+class \nodoc\ iso _TestTrimWithInclude is UnitTest
+  fun name(): String => "Trim: with include"
+
+  fun apply(h: TestHelper)? =>
+    let ctx = TemplateContext(
+      recover Map[String, {(String): String}] end,
+      recover val
+        let p = Map[String, String]
+        p("part") = "included"
+        p
+      end)
+    h.assert_eq[String]("beforeincludedafter",
+      Template.parse(
+        "before   {{- include \"part\" -}}   after", ctx)?
+        .render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestTrimWithExtends is UnitTest
+  fun name(): String => "Trim: extends with trim markers"
+
+  fun apply(h: TestHelper)? =>
+    let ctx = TemplateContext(
+      recover Map[String, {(String): String}] end,
+      recover val
+        let p = Map[String, String]
+        p("base") = "hello {{ block content }}default{{ end }}"
+        p
+      end)
+    // Trim markers on extends should parse correctly
+    let template = Template.parse(
+      "{{- extends \"base\" -}}" +
+      "{{ block content }}world{{ end }}", ctx)?
+    let values = TemplateValues
+    h.assert_eq[String]("hello world", template.render(values)?)
+
+
+class \nodoc\ iso _TestTrimAdjacentTags is UnitTest
+  fun name(): String => "Trim: adjacent tags with no literal between"
+
+  fun apply(h: TestHelper)? =>
+    let values = TemplateValues
+    values("a") = "one"
+    values("b") = "two"
+    // -}} on first tag should strip leading whitespace from text after
+    // second tag, even though there's no literal between the two tags
+    h.assert_eq[String]("onetwotext",
+      Template.parse("{{ a -}}{{ b -}}   text")?.render(values)?)
+
+
+class \nodoc\ iso _TestTrimAtStart is UnitTest
+  fun name(): String => "Trim: left trim at start of template"
+
+  fun apply(h: TestHelper)? =>
+    let values = TemplateValues
+    values("x") = "hello"
+    // {{- at very start — no preceding literal to strip
+    h.assert_eq[String]("hello",
+      Template.parse("{{- x }}")?.render(values)?)
+
+
+class \nodoc\ iso _TestTrimAtEnd is UnitTest
+  fun name(): String => "Trim: right trim at end of template"
+
+  fun apply(h: TestHelper)? =>
+    let values = TemplateValues
+    values("x") = "hello"
+    // -}} at very end — no following literal to strip
+    h.assert_eq[String]("hello",
+      Template.parse("{{ x -}}")?.render(values)?)
+
+
+class \nodoc\ iso _TestTrimProducesEmptyLiteral is UnitTest
+  fun name(): String => "Trim: trimming produces empty literal (skipped)"
+
+  fun apply(h: TestHelper)? =>
+    let values = TemplateValues
+    values("a") = "one"
+    values("b") = "two"
+    // The spaces between tags get fully trimmed away
+    h.assert_eq[String]("onetwo",
+      Template.parse("{{ a -}}   {{- b }}")?.render(values)?)
+
+
+class \nodoc\ iso _PropTrimDeterminism is Property1[String]
+  """
+  Templates with trim markers produce the same output on repeated renders.
+  """
+  fun name(): String => "Trim: deterministic rendering"
+
+  fun gen(): Generator[String] =>
+    _Generators.valid_name()
+
+  fun property(name': String, h: PropertyHelper)? =>
+    let source: String val = "  {{- " + name' + " -}}  "
+    let template = Template.parse(source)?
+    let values = TemplateValues
+    values(name') = "val"
+    let r1 = template.render(values)?
+    let r2 = template.render(values)?
+    h.assert_eq[String](r1, r2)
 
 
 // ---------------------------------------------------------------------------

--- a/templates/template.pony
+++ b/templates/template.pony
@@ -29,6 +29,11 @@ blocks. Supported block types:
   their default content from the base. Multi-level inheritance is supported.
   Content outside `{{ block }}` definitions in a child template is silently
   ignored. Circular extends chains are detected at parse time.
+* **Whitespace trimming**: `{{-` strips trailing whitespace from the preceding
+  literal, `-}}` strips leading whitespace from the following literal. Either
+  or both can be used independently: `{{- x -}}`. Whitespace includes spaces,
+  tabs, and newlines. Useful for generating indentation-sensitive output like
+  YAML without unwanted blank lines from control flow tags.
 """
 
 use "collections"
@@ -245,6 +250,7 @@ class val Template
     var current_parts = parts
     var open: Array[((_IfNode | _IfNotNode | _LoopNode | _IfElse | _BlockNode), Array[_Part], Bool)] = []
     var first_stmt: Bool = true
+    var trim_next_literal: Bool = false
     var prev_end: ISize = 0
     while prev_end < source.size().isize() do
       let start_pos =
@@ -253,12 +259,36 @@ class val Template
       let end_pos =
         try _find_close_delim(source, start_pos + 2)?
         else break end
-      if start_pos != prev_end then
-        let literal = source.substring(prev_end.isize(), start_pos)
-        current_parts.push((_Literal, consume literal))
-      end
 
-      let stmt_source: String = source.substring(start_pos + 2, end_pos)
+      // Detect {{- (left trim) and -}} (right trim)
+      let left_trim =
+        try source((start_pos + 2).usize())? == '-'
+        else false
+        end
+      let stmt_start: ISize =
+        if left_trim then start_pos + 3 else start_pos + 2 end
+      let right_trim =
+        try
+          (end_pos > stmt_start) and (source((end_pos - 1).usize())? == '-')
+        else false
+        end
+      let stmt_end: ISize =
+        if right_trim then end_pos - 1 else end_pos end
+
+      if start_pos != prev_end then
+        var literal = source.substring(prev_end.isize(), start_pos)
+        if trim_next_literal then literal.lstrip() end
+        if left_trim then literal.rstrip() end
+        if literal.size() > 0 then
+          current_parts.push((_Literal, consume literal))
+        end
+      else
+        // No literal between tags, but reset trim_next_literal below
+        None
+      end
+      trim_next_literal = right_trim
+
+      let stmt_source: String = source.substring(stmt_start, stmt_end)
       match _StmtParser.parse(stmt_source)?
       | _EndNode => current_parts = _parse_end(open, parts)?
       | _ElseNode => current_parts = _parse_else(open)?
@@ -302,7 +332,11 @@ class val Template
     end
 
     if prev_end < source.size().isize() then
-      parts.push((_Literal, source.substring(prev_end.isize())))
+      var trailing = source.substring(prev_end.isize())
+      if trim_next_literal then trailing.lstrip() end
+      if trailing.size() > 0 then
+        parts.push((_Literal, consume trailing))
+      end
     end
 
     if open.size() > 0 then error end
@@ -428,7 +462,20 @@ class val Template
       try _find_close_delim(source, start_pos + 2)?
       else return None
       end
-    let stmt_source: String val = source.substring(start_pos + 2, end_pos)
+    let left_trim =
+      try source((start_pos + 2).usize())? == '-'
+      else false
+      end
+    let stmt_start: ISize =
+      if left_trim then start_pos + 3 else start_pos + 2 end
+    let right_trim =
+      try
+        (end_pos > stmt_start) and (source((end_pos - 1).usize())? == '-')
+      else false
+      end
+    let stmt_end: ISize =
+      if right_trim then end_pos - 1 else end_pos end
+    let stmt_source: String val = source.substring(stmt_start, stmt_end)
     match _StmtParser.parse(stmt_source)?
     | let ext: _ExtendsNode => ext.name
     else None


### PR DESCRIPTION
Templates now support `{{-` and `-}}` trim markers that strip whitespace from adjacent literals at parse time. `{{-` removes trailing whitespace from the preceding literal, `-}}` removes leading whitespace from the following literal. Either or both can be used independently.

This is the standard Jinja2/Go/Liquid convention for whitespace control, identified as a high-priority feature in the design discussion (#38). It lets template authors generate indentation-sensitive output (YAML, Python) without unwanted blank lines from control flow tags.

The implementation detects trim markers in `_parse()` and `_check_extends()`, adjusts statement source boundaries to exclude the `-` characters, and applies `lstrip()`/`rstrip()` to adjacent literals. A `trim_next_literal` flag propagates right-trim across adjacent tags with no intervening literal. Empty literals after trimming are skipped.