### PR TITLE
Add title built-in filter

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -164,12 +164,13 @@ The right-trim on the `for` tag strips the newline that would otherwise appear b
 
 Function calls (`{{ fn(arg) }}`) have been replaced by a filter/pipe system. Values are now transformed by piping them through one or more filters: `{{ value | filter1 | filter2 }}`.
 
-Six built-in filters are available in all templates without registration:
+Seven built-in filters are available in all templates without registration:
 
 - `upper` — uppercase
 - `lower` — lowercase
 - `trim` — strip leading/trailing whitespace
 - `capitalize` — first character upper, rest lower
+- `title` — title case each word
 - `default("fallback")` — use fallback when the value is empty or missing
 - `replace("old", "new")` — replace all occurrences
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ Parses a template with a single placeholder, binds a value, and renders the resu
 
 ## [filters-example](filters-example/)
 
-Uses the filter/pipe system to transform values. Demonstrates built-in filters (`upper`, `trim`, `capitalize`, `default`), chaining multiple filters (`{{ greeting | trim | capitalize }}`), custom filter registration via `TemplateContext`, and filters inside loops.
+Uses the filter/pipe system to transform values. Demonstrates built-in filters (`upper`, `trim`, `capitalize`, `title`, `default`), chaining multiple filters (`{{ greeting | trim | capitalize }}`), custom filter registration via `TemplateContext`, and filters inside loops.
 
 ## [conditionals-example](conditionals-example/)
 

--- a/examples/filters-example/filters-example.pony
+++ b/examples/filters-example/filters-example.pony
@@ -22,8 +22,8 @@ primitive Repeat is Filter2
 actor Main
   new create(env: Env) =>
     // Register a custom filter via TemplateContext.
-    // Built-in filters (upper, lower, trim, capitalize, default, replace)
-    // are always available without registration.
+    // Built-in filters (upper, lower, trim, capitalize, title, default,
+    // replace) are always available without registration.
     let ctx = TemplateContext(
       recover val
         let filters = Map[String, AnyFilter]
@@ -49,6 +49,15 @@ actor Main
       v2("greeting") = "  hello world  "
       env.out.print(t2.render(v2)?)
       // Output: Greeting: Hello world
+    end
+
+    // Title case: capitalize the first letter of each word
+    try
+      let t = Template.parse("{{ name | title }}", ctx)?
+      let v = TemplateValues
+      v("name") = "hello world"
+      env.out.print(t.render(v)?)
+      // Output: Hello World
     end
 
     // Default filter: fallback when a variable is missing

--- a/templates/_test.pony
+++ b/templates/_test.pony
@@ -85,6 +85,7 @@ actor \nodoc\ Main is TestList
     test(_TestRenderPipeLower)
     test(_TestRenderPipeTrim)
     test(_TestRenderPipeCapitalize)
+    test(_TestRenderPipeTitle)
     test(_TestRenderPipeDefault)
     test(_TestRenderPipeReplace)
     test(_TestRenderPipeChain)
@@ -1637,6 +1638,43 @@ class \nodoc\ iso _TestRenderPipeCapitalize is UnitTest
     let v3 = TemplateValues
     v3("name") = "a"
     h.assert_eq[String]("A", template.render(v3)?)
+
+
+class \nodoc\ iso _TestRenderPipeTitle is UnitTest
+  fun name(): String => "Render: pipe title filter"
+
+  fun apply(h: TestHelper)? =>
+    let template = Template.parse("{{ name | title }}")?
+
+    // Basic title case
+    let v1 = TemplateValues
+    v1("name") = "hello world"
+    h.assert_eq[String]("Hello World", template.render(v1)?)
+
+    // Already uppercased letters get lowered
+    let v2 = TemplateValues
+    v2("name") = "hELLO wORLD"
+    h.assert_eq[String]("Hello World", template.render(v2)?)
+
+    // Empty string
+    let v3 = TemplateValues
+    v3("name") = ""
+    h.assert_eq[String]("", template.render(v3)?)
+
+    // Single word
+    let v4 = TemplateValues
+    v4("name") = "hello"
+    h.assert_eq[String]("Hello", template.render(v4)?)
+
+    // Multiple whitespace types
+    let v5 = TemplateValues
+    v5("name") = "hello\tworld\nnow"
+    h.assert_eq[String]("Hello\tWorld\nNow", template.render(v5)?)
+
+    // Multiple consecutive spaces preserved
+    let v6 = TemplateValues
+    v6("name") = "hello  world"
+    h.assert_eq[String]("Hello  World", template.render(v6)?)
 
 
 class \nodoc\ iso _TestRenderPipeDefault is UnitTest

--- a/templates/builtin_filters.pony
+++ b/templates/builtin_filters.pony
@@ -78,6 +78,42 @@ primitive Default is Filter2
   fun apply(input: String, arg1: String): String =>
     if input.size() == 0 then arg1 else input end
 
+primitive Title is Filter
+  """
+  Converts the input to title case (first character of each word uppercased,
+  rest lowercased, ASCII only). Words are delimited by whitespace.
+
+  ```
+  {{ name | title }}
+  ```
+  """
+  fun apply(input: String): String =>
+    if input.size() == 0 then return "" end
+    let out = recover iso String(input.size()) end
+    var word_start = true
+    for byte in input.values() do
+      if (byte == ' ') or (byte == '\t') or (byte == '\n')
+        or (byte == '\r')
+      then
+        out.push(byte)
+        word_start = true
+      elseif word_start then
+        if (byte >= 'a') and (byte <= 'z') then
+          out.push(byte - 0x20)
+        else
+          out.push(byte)
+        end
+        word_start = false
+      else
+        if (byte >= 'A') and (byte <= 'Z') then
+          out.push(byte + 0x20)
+        else
+          out.push(byte)
+        end
+      end
+    end
+    consume out
+
 primitive Replace is Filter3
   """
   Replaces all occurrences of `arg1` with `arg2` in the input.

--- a/templates/template.pony
+++ b/templates/template.pony
@@ -14,9 +14,9 @@ blocks. Supported block types:
 * **Loops**: `{{ for item in items }}...{{ end }}`
 * **Filters**: `{{ name | upper }}` pipes a value through one or more
   filters. Filters are chained left-to-right:
-  `{{ name | trim | upper | default("ANON") }}`. Six built-in filters are
+  `{{ name | trim | upper | default("ANON") }}`. Seven built-in filters are
   available without registration: `upper`, `lower`, `trim`, `capitalize`,
-  `default("fallback")`, and `replace("old", "new")`. Custom filters can
+  `title`, `default("fallback")`, and `replace("old", "new")`. Custom filters can
   be registered via `TemplateContext`. Filter arguments can be string
   literals (`"hello"`) or template variables (`varname`).
 * **Includes**: `{{ include "name" }}` inlines a named partial registered via
@@ -221,8 +221,8 @@ class TemplateContext
   be inlined via `{{ include "name" }}` or used as base templates for
   inheritance via `{{ extends "name" }}`.
 
-  Six built-in filters are always available: `upper`, `lower`, `trim`,
-  `capitalize`, `default`, and `replace`. User-supplied filters with the
+  Seven built-in filters are always available: `upper`, `lower`, `trim`,
+  `capitalize`, `title`, `default`, and `replace`. User-supplied filters with the
   same name override the built-in.
   """
   let filters: Map[String, AnyFilter] box
@@ -239,6 +239,7 @@ class TemplateContext
     merged("lower") = Lower
     merged("trim") = Trim
     merged("capitalize") = Capitalize
+    merged("title") = Title
     merged("default") = Default
     merged("replace") = Replace
     for (k, v) in filters'.pairs() do


### PR DESCRIPTION
Adds a `title` filter that title-cases each word (first letter upper, rest lower, ASCII, whitespace-delimited). Phase 2 of the filter/pipe design (Discussion #54).

Purely additive — no grammar or API changes. The `Title` primitive implements `Filter`, is registered as a built-in in `TemplateContext`, and can be overridden like any other built-in.