### PR TITLE
Add template comments

### DIFF
--- a/.release-notes/template-comments.md
+++ b/.release-notes/template-comments.md
@@ -1,0 +1,17 @@
+## Add template comments
+
+Templates now support comments with `{{! ... }}` syntax. Everything between `!` and `}}` is discarded during rendering, so comments never appear in the output.
+
+```pony
+let t = Template.parse("Hello {{! a comment }} world")?
+t.render(TemplateValues)? // => "Hello  world"
+```
+
+Trim markers work with comments the same way they work with any other block type:
+
+```pony
+Template.parse("Hello{{-! trimmed -}}world")?
+  .render(TemplateValues)? // => "Helloworld"
+```
+
+Comments can appear anywhere a normal block can: inside `if`/`else` bodies, loop bodies, and before `extends` declarations. They are transparent to the template engine — a comment before `{{ extends "base" }}` does not prevent the extends from being recognized as the first statement.

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,10 @@ Each subdirectory is a self-contained Pony program demonstrating a different par
 
 Parses a template with a single placeholder, binds a value, and renders the result. Demonstrates the core workflow: `Template.parse()`, `TemplateValues`, and `Template.render()`. Start here if you're new to the library.
 
+## [comments-example](comments-example/)
+
+Uses `{{! ... }}` syntax to add comments to templates. Comments are stripped from the output entirely, so they're useful for documenting template logic without affecting rendered text. Shows basic comments and comments combined with trim markers inside loops.
+
 ## [filters-example](filters-example/)
 
 Uses the filter/pipe system to transform values. Demonstrates built-in filters (`upper`, `trim`, `capitalize`, `title`, `default`), chaining multiple filters (`{{ greeting | trim | capitalize }}`), string literals as pipe sources (`{{ "hello world" | upper }}`), custom filter registration via `TemplateContext`, and filters inside loops.

--- a/examples/comments-example/comments-example.pony
+++ b/examples/comments-example/comments-example.pony
@@ -1,0 +1,60 @@
+// This example demonstrates template comments using {{! ... }} syntax.
+// Comments are stripped from the output entirely — useful for documenting
+// template logic without polluting rendered text.
+
+// In your code this `use` statement would be:
+// use "templates"
+use "../../templates"
+
+use "collections"
+
+actor Main
+  new create(env: Env) =>
+    let values = TemplateValues
+    values("name") = "world"
+    values("items") = TemplateValue(
+      recover val
+        let s = Array[TemplateValue]
+        s.push(TemplateValue("alpha"))
+        s.push(TemplateValue("beta"))
+        s
+      end)
+
+    // Basic comment — the {{! ... }} block is invisible in the output
+    let basic =
+      try
+        Template.parse(
+          "Hello {{! greeting target }} {{ name }}!")?
+      else
+        env.err.print("Could not parse template :(")
+        env.exitcode(1)
+        return
+      end
+
+    try
+      env.out.print(basic.render(values)?)
+    else
+      env.err.print("Could not render template :(")
+      env.exitcode(1)
+      return
+    end
+
+    // Comments with trim markers remove surrounding whitespace, just like
+    // any other block type. Useful inside loops to avoid extra blank lines.
+    let trimmed =
+      try
+        Template.parse(
+          "items:\n" +
+          "{{ for item in items -}}\n" +
+          "{{-! Document each list entry -}}\n" +
+          "- {{ item }}\n" +
+          "{{ end }}")?
+      else
+        env.err.print("Could not parse template :(")
+        env.exitcode(1)
+        return
+      end
+
+    try
+      env.out.print(trimmed.render(values)?)
+    end

--- a/templates/_test.pony
+++ b/templates/_test.pony
@@ -169,6 +169,21 @@ actor \nodoc\ Main is TestList
     test(_TestTrimProducesEmptyLiteral)
     test(Property1UnitTest[String](_PropTrimDeterminism))
 
+    // Comment tests
+    test(Property1UnitTest[String](_PropCommentInvisible))
+    test(Property1UnitTest[(String, String)](_PropCommentBodyIrrelevant))
+    test(_TestCommentBasic)
+    test(_TestCommentWithTrim)
+    test(_TestCommentBeforeExtends)
+    test(_TestCommentInsideIf)
+    test(_TestCommentInsideLoop)
+    test(_TestCommentInsideElse)
+    test(_TestCommentAsOnlyBlockContent)
+    test(_TestCommentAdjacent)
+    test(_TestCommentBetweenLiterals)
+    test(_TestCommentMinimal)
+    test(_TestCommentWithQuotes)
+
     // from_file test (Step 8)
     test(_TestFromFile)
 
@@ -367,6 +382,29 @@ primitive \nodoc\ _Generators
       " !#$%&'()*+,-./0123456789:;<=>?@"
       + "ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`"
       + "abcdefghijklmnopqrstuvwxyz{|}~"
+    Generator[String](
+      object is GenObj[String]
+        fun generate(rnd: Randomness): String^ =>
+          let len = rnd.usize(0, 30)
+          let s = recover iso String(len) end
+          var i: USize = 0
+          while i < len do
+            try s.push(chars(rnd.usize(0, chars.size() - 1))?) end
+            i = i + 1
+          end
+          consume s
+      end)
+
+  fun comment_body(): Generator[String] =>
+    """
+    Generates printable ASCII strings 0-30 chars, excluding `}` so that `}}`
+    can never appear inside the comment body.
+    """
+    let chars: String val =
+      " !\"#$%&'()*+,-./"
+      + "0123456789:;<=>?@"
+      + "ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`"
+      + "abcdefghijklmnopqrstuvwxyz{|~"
     Generator[String](
       object is GenObj[String]
         fun generate(rnd: Randomness): String^ =>
@@ -2860,6 +2898,195 @@ class \nodoc\ iso _PropPipeLiteralUpper is Property1[String]
     end
     let result = Template.parse(source)?.render(TemplateValues)?
     h.assert_eq[String](sample.upper(), result)
+
+
+// ---------------------------------------------------------------------------
+// Comment tests
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _PropCommentInvisible is Property1[String]
+  """
+  For any generated comment body, `{{! body }}` renders as empty string.
+  """
+  fun name(): String => "Prop: comment renders as empty string"
+
+  fun gen(): Generator[String] =>
+    _Generators.comment_body()
+
+  fun property(sample: String, h: PropertyHelper)? =>
+    let source = recover val "{{!" + sample + "}}" end
+    h.assert_eq[String]("",
+      Template.parse(source)?.render(TemplateValues)?)
+
+
+class \nodoc\ iso _PropCommentBodyIrrelevant
+  is Property1[(String, String)]
+  """
+  Two templates differing only in comment body render identically, proving
+  comment content is truly discarded.
+  """
+  fun name(): String => "Prop: comment body is irrelevant to output"
+
+  fun gen(): Generator[(String, String)] =>
+    Generators.zip2[String, String](
+      _Generators.comment_body(),
+      _Generators.comment_body())
+
+  fun property(sample: (String, String), h: PropertyHelper)? =>
+    (let body1, let body2) = sample
+    let source1 = recover val "before{{!" + body1 + "}}after" end
+    let source2 = recover val "before{{!" + body2 + "}}after" end
+    let r1 = Template.parse(source1)?.render(TemplateValues)?
+    let r2 = Template.parse(source2)?.render(TemplateValues)?
+    h.assert_eq[String](r1, r2)
+
+
+class \nodoc\ iso _TestCommentBasic is UnitTest
+  fun name(): String => "Comment: basic comment is invisible"
+
+  fun apply(h: TestHelper)? =>
+    h.assert_eq[String]("hello  world",
+      Template.parse("hello {{! ignored }} world")?.render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestCommentWithTrim is UnitTest
+  fun name(): String => "Comment: trim markers with comments"
+
+  fun apply(h: TestHelper)? =>
+    // Right-trim strips leading whitespace from following literal
+    h.assert_eq[String]("helloworld",
+      Template.parse("hello{{! comment -}}   world")?
+        .render(TemplateValues)?)
+    // Left-trim strips trailing whitespace from preceding literal
+    h.assert_eq[String]("helloworld",
+      Template.parse("hello   {{-! comment }}world")?
+        .render(TemplateValues)?)
+    // Both trims
+    h.assert_eq[String]("helloworld",
+      Template.parse("hello   {{-! comment -}}   world")?
+        .render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestCommentBeforeExtends is UnitTest
+  fun name(): String => "Comment: comment before extends is transparent"
+
+  fun apply(h: TestHelper)? =>
+    let partials = recover val
+      let p = Map[String, String]
+      p("base") = "BASE:{{ block main }}default{{ end }}"
+      p
+    end
+    let ctx = TemplateContext(where partials' = partials)
+    // Comment before extends — should work fine
+    let child = "{{! layout comment }}{{ extends \"base\" }}{{ block main }}override{{ end }}"
+    h.assert_eq[String]("BASE:override",
+      Template.parse(child, ctx)?.render(TemplateValues)?)
+    // Extends after a non-comment block should still fail
+    h.assert_error({()? =>
+      Template.parse(
+        "{{ x }}{{ extends \"base\" }}{{ block main }}override{{ end }}",
+        ctx)?
+    })
+
+
+class \nodoc\ iso _TestCommentInsideIf is UnitTest
+  fun name(): String => "Comment: inside if body"
+
+  fun apply(h: TestHelper)? =>
+    let values = TemplateValues
+    values("show") = "yes"
+    h.assert_eq[String]("visible",
+      Template.parse("{{ if show }}{{! hidden note }}visible{{ end }}")?
+        .render(values)?)
+
+
+class \nodoc\ iso _TestCommentInsideLoop is UnitTest
+  fun name(): String => "Comment: inside loop body"
+
+  fun apply(h: TestHelper)? =>
+    let values = TemplateValues
+    values("items") = TemplateValue(
+      [TemplateValue("a"); TemplateValue("b")])
+    h.assert_eq[String]("ab",
+      Template.parse(
+        "{{ for x in items }}{{! loop comment }}{{ x }}{{ end }}")?
+        .render(values)?)
+
+
+class \nodoc\ iso _TestCommentInsideElse is UnitTest
+  fun name(): String => "Comment: inside else branch"
+
+  fun apply(h: TestHelper)? =>
+    h.assert_eq[String]("fallback",
+      Template.parse(
+        "{{ if missing }}yes{{ else }}{{! else comment }}fallback{{ end }}")?
+        .render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestCommentAsOnlyBlockContent is UnitTest
+  fun name(): String => "Comment: as sole content of if/loop body"
+
+  fun apply(h: TestHelper)? =>
+    let values = TemplateValues
+    values("show") = "yes"
+    // Comment as only content of if body produces empty body
+    h.assert_eq[String]("",
+      Template.parse("{{ if show }}{{! only a comment }}{{ end }}")?
+        .render(values)?)
+    // Comment as only content of loop body
+    values("items") = TemplateValue(
+      [TemplateValue("a"); TemplateValue("b")])
+    h.assert_eq[String]("",
+      Template.parse(
+        "{{ for x in items }}{{! only a comment }}{{ end }}")?
+        .render(values)?)
+
+
+class \nodoc\ iso _TestCommentAdjacent is UnitTest
+  fun name(): String => "Comment: multiple adjacent comments"
+
+  fun apply(h: TestHelper)? =>
+    h.assert_eq[String]("ab",
+      Template.parse("a{{! one }}{{! two }}{{! three }}b")?
+        .render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestCommentBetweenLiterals is UnitTest
+  fun name(): String => "Comment: between literals produces concatenation"
+
+  fun apply(h: TestHelper)? =>
+    h.assert_eq[String]("ab",
+      Template.parse("a{{! comment }}b")?.render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestCommentMinimal is UnitTest
+  fun name(): String => "Comment: minimal forms"
+
+  fun apply(h: TestHelper)? =>
+    // Just the exclamation mark, no body
+    h.assert_eq[String]("",
+      Template.parse("{{!}}")?.render(TemplateValues)?)
+    // Exclamation mark with whitespace
+    h.assert_eq[String]("",
+      Template.parse("{{! }}")?.render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestCommentWithQuotes is UnitTest
+  fun name(): String => "Comment: double quotes inside comment body"
+
+  fun apply(h: TestHelper)? =>
+    // A " inside a comment must not trigger quote-aware delimiter scanning
+    h.assert_eq[String]("ab",
+      Template.parse("a{{! she said \"hello\" }}b")?
+        .render(TemplateValues)?)
+    // Single unmatched quote
+    h.assert_eq[String]("ab",
+      Template.parse("a{{! it's a \" quote }}b")?
+        .render(TemplateValues)?)
+    // Single } inside comment (legal — only }} closes)
+    h.assert_eq[String]("ab",
+      Template.parse("a{{! single } brace }}b")?
+        .render(TemplateValues)?)
 
 
 // ---------------------------------------------------------------------------

--- a/templates/template.pony
+++ b/templates/template.pony
@@ -36,6 +36,9 @@ blocks. Supported block types:
   or both can be used independently: `{{- x -}}`. Whitespace includes spaces,
   tabs, and newlines. Useful for generating indentation-sensitive output like
   YAML without unwanted blank lines from control flow tags.
+* **Comments**: `{{! ... }}` is ignored during rendering. Everything between `!`
+  and `}}` is discarded. Comments can appear anywhere a normal block can appear,
+  and trim markers work as expected: `{{!- comment -}}`.
 """
 
 use "collections"
@@ -285,8 +288,15 @@ class val Template
       let start_pos =
         try source.find("{{" where offset = prev_end)?
         else break end
+      // Comments don't use quote-aware scanning — a `"` inside a comment
+      // body is literal text, not a string delimiter.
       let end_pos =
-        try _find_close_delim(source, start_pos + 2)?
+        try
+          if _is_comment_open(source, start_pos) then
+            source.find("}}" where offset = start_pos + 2)?
+          else
+            _find_close_delim(source, start_pos + 2)?
+          end
         else break end
 
       // Detect {{- (left trim) and -}} (right trim)
@@ -318,6 +328,16 @@ class val Template
       trim_next_literal = right_trim
 
       let stmt_source: String = source.substring(stmt_start, stmt_end)
+
+      // Skip comment blocks: {{! ... }}
+      let stripped_stmt: String val = stmt_source.clone().>strip()
+      if (stripped_stmt.size() > 0) and
+        try stripped_stmt(0)? == '!' else false end
+      then
+        prev_end = end_pos + 2
+        continue
+      end
+
       match _StmtParser.parse(stmt_source)?
       | _EndNode => current_parts = _parse_end(open, parts)?
       | _ElseNode => current_parts = _parse_else(open)?
@@ -514,32 +534,51 @@ class val Template
     end
 
   fun tag _check_extends(source: String): (String | None)? =>
-    let start_pos =
-      try source.find("{{")?
+    var search_from: ISize = 0
+    while search_from < source.size().isize() do
+      let start_pos =
+        try source.find("{{" where offset = search_from)?
+        else return None
+        end
+      let end_pos =
+        try
+          if _is_comment_open(source, start_pos) then
+            source.find("}}" where offset = start_pos + 2)?
+          else
+            _find_close_delim(source, start_pos + 2)?
+          end
+        else return None
+        end
+      let left_trim =
+        try source((start_pos + 2).usize())? == '-'
+        else false
+        end
+      let stmt_start: ISize =
+        if left_trim then start_pos + 3 else start_pos + 2 end
+      let right_trim =
+        try
+          (end_pos > stmt_start) and (source((end_pos - 1).usize())? == '-')
+        else false
+        end
+      let stmt_end: ISize =
+        if right_trim then end_pos - 1 else end_pos end
+      let stmt_source: String val = source.substring(stmt_start, stmt_end)
+
+      // Skip comment blocks
+      let stripped_stmt: String val = stmt_source.clone().>strip()
+      if (stripped_stmt.size() > 0) and
+        try stripped_stmt(0)? == '!' else false end
+      then
+        search_from = end_pos + 2
+        continue
+      end
+
+      match _StmtParser.parse(stmt_source)?
+      | let ext: _ExtendsNode => return ext.name
       else return None
       end
-    let end_pos =
-      try _find_close_delim(source, start_pos + 2)?
-      else return None
-      end
-    let left_trim =
-      try source((start_pos + 2).usize())? == '-'
-      else false
-      end
-    let stmt_start: ISize =
-      if left_trim then start_pos + 3 else start_pos + 2 end
-    let right_trim =
-      try
-        (end_pos > stmt_start) and (source((end_pos - 1).usize())? == '-')
-      else false
-      end
-    let stmt_end: ISize =
-      if right_trim then end_pos - 1 else end_pos end
-    let stmt_source: String val = source.substring(stmt_start, stmt_end)
-    match _StmtParser.parse(stmt_source)?
-    | let ext: _ExtendsNode => ext.name
-    else None
     end
+    None
 
   fun tag _extract_blocks(
     parts: Array[_Part] box
@@ -603,6 +642,28 @@ class val Template
       end
     end
     result
+
+  fun tag _is_comment_open(source: String, start_pos: ISize): Bool =>
+    """
+    Check whether the `{{ }}` block starting at `start_pos` is a comment.
+    Peeks past the opening `{{` and optional `-` trim marker to see if the
+    next non-whitespace character is `!`.
+    """
+    var i = (start_pos + 2).usize()
+    let limit = source.size()
+    // Skip optional trim marker
+    try if source(i)? == '-' then i = i + 1 end end
+    // Skip whitespace
+    while i < limit do
+      try
+        let c = source(i)?
+        if (c == ' ') or (c == '\t') then i = i + 1
+        else return c == '!'
+        end
+      else return false
+      end
+    end
+    false
 
   fun tag _find_close_delim(source: String, from: ISize): ISize? =>
     """


### PR DESCRIPTION
Templates now support comments with `{{! ... }}` syntax. Content between `!` and `}}` is discarded during rendering.

Comments work anywhere a normal block can appear — inside `if`/`else` bodies, loop bodies, and before `extends` declarations. Trim markers work as expected: `{{-! comment -}}`.

Comment bodies are opaque text, so they bypass the quote-aware delimiter scanner. A `"` or `}` inside a comment is literal content, not a parser token.

The `_check_extends` function now loops over blocks to skip leading comments, so `{{! note }}{{ extends "base" }}` is recognized correctly.

Includes a new `comments-example` program demonstrating basic comments and comments with trim markers inside loops.

Design: #38