### PR TITLE
Add raw / literal blocks

### DIFF
--- a/.release-notes/add-raw-blocks.md
+++ b/.release-notes/add-raw-blocks.md
@@ -1,0 +1,12 @@
+## Add raw / literal blocks
+
+Raw blocks let you output literal `{{ }}` delimiters without the engine interpreting them. Wrap content in `{{raw}}...{{end}}` and everything between the tags is emitted as-is:
+
+```pony
+let t = Template.parse("{{raw}}{{ name }}{{end}}")?
+t.render(TemplateValues)?  // => "{{ name }}"
+```
+
+Trim markers work on both tags (`{{- raw -}}...{{- end -}}`), following the same rules as other block types.
+
+The first `{{ end }}` always closes the raw block, so literal `{{ end }}` cannot appear inside raw content. This is the same class of limitation as `}}` inside comments.

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,10 @@ Each subdirectory is a self-contained Pony program demonstrating a different par
 
 Parses a template with a single placeholder, binds a value, and renders the result. Demonstrates the core workflow: `Template.parse()`, `TemplateValues`, and `Template.render()`. Start here if you're new to the library.
 
+## [raw-example](raw-example/)
+
+Uses `{{raw}}...{{end}}` syntax to emit literal text without interpreting `{{ }}` sequences inside it. Useful when the template output itself contains delimiter syntax — for example, generating Mustache templates or documentation about this library. Shows basic raw output and raw blocks combined with trim markers.
+
 ## [comments-example](comments-example/)
 
 Uses `{{! ... }}` syntax to add comments to templates. Comments are stripped from the output entirely, so they're useful for documenting template logic without affecting rendered text. Shows basic comments and comments combined with trim markers inside loops.

--- a/examples/raw-example/raw-example.pony
+++ b/examples/raw-example/raw-example.pony
@@ -1,0 +1,45 @@
+// This example demonstrates raw blocks using {{raw}}...{{end}} syntax.
+// Everything between the tags is emitted as literal text — no {{ }}
+// interpretation occurs. Useful when template output itself contains
+// delimiter syntax.
+
+// In your code this `use` statement would be:
+// use "templates"
+use "../../templates"
+
+actor Main
+  new create(env: Env) =>
+    // Basic raw output — {{ name }} passes through literally
+    let basic =
+      try
+        Template.parse(
+          "Template syntax: {{raw}}{{ name }}{{end}}")?
+      else
+        env.err.print("Could not parse template :(")
+        env.exitcode(1)
+        return
+      end
+
+    try
+      env.out.print(basic.render(TemplateValues)?)
+    else
+      env.err.print("Could not render template :(")
+      env.exitcode(1)
+      return
+    end
+
+    // Raw block with trim markers — strips surrounding whitespace while
+    // still emitting the raw content literally
+    let trimmed =
+      try
+        Template.parse(
+          "before\n{{- raw -}}\n{{ delimiters }}\n{{- end -}}\nafter")?
+      else
+        env.err.print("Could not parse template :(")
+        env.exitcode(1)
+        return
+      end
+
+    try
+      env.out.print(trimmed.render(TemplateValues)?)
+    end

--- a/templates/_test.pony
+++ b/templates/_test.pony
@@ -184,6 +184,23 @@ actor \nodoc\ Main is TestList
     test(_TestCommentMinimal)
     test(_TestCommentWithQuotes)
 
+    // Raw block tests
+    test(Property1UnitTest[String](_PropRawBlockContentIdentity))
+    test(Property1UnitTest[String](_PropRawBlockSurroundingLiteralsPreserved))
+    test(_TestRawBasic)
+    test(_TestRawWithTrim)
+    test(_TestRawWithTemplateDelimiters)
+    test(_TestRawInsideIf)
+    test(_TestRawInsideLoop)
+    test(_TestRawInsideElse)
+    test(_TestRawBeforeExtends)
+    test(_TestRawAdjacent)
+    test(_TestRawBetweenLiterals)
+    test(_TestRawEmpty)
+    test(_TestRawUnclosed)
+    test(_TestRawMinimal)
+    test(_TestRawWithBraces)
+
     // from_file test (Step 8)
     test(_TestFromFile)
 
@@ -241,6 +258,8 @@ primitive \nodoc\ _Generators
             end
           end
         end
+        // Reject "raw" exactly (reserved keyword for raw blocks)
+        if s == "raw" then return (consume s, false) end
         // Reject names starting with "block" + alpha/underscore
         // (parses as _BlockNode, same as "iffy" → _IfNode)
         if (s.size() >= 6) and s.at("block", 0) then
@@ -405,6 +424,30 @@ primitive \nodoc\ _Generators
       + "0123456789:;<=>?@"
       + "ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`"
       + "abcdefghijklmnopqrstuvwxyz{|~"
+    Generator[String](
+      object is GenObj[String]
+        fun generate(rnd: Randomness): String^ =>
+          let len = rnd.usize(0, 30)
+          let s = recover iso String(len) end
+          var i: USize = 0
+          while i < len do
+            try s.push(chars(rnd.usize(0, chars.size() - 1))?) end
+            i = i + 1
+          end
+          consume s
+      end)
+
+  fun raw_body(): Generator[String] =>
+    """
+    Generates printable ASCII strings 0-30 chars, excluding `{` so that `{{`
+    can never form inside the generated content and accidentally create
+    `{{end}}`.
+    """
+    let chars: String val =
+      " !\"#$%&'()*+,-./"
+      + "0123456789:;<=>?@"
+      + "ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`"
+      + "abcdefghijklmnopqrstuvwxyz|}~"
     Generator[String](
       object is GenObj[String]
         fun generate(rnd: Randomness): String^ =>
@@ -3086,6 +3129,221 @@ class \nodoc\ iso _TestCommentWithQuotes is UnitTest
     // Single } inside comment (legal — only }} closes)
     h.assert_eq[String]("ab",
       Template.parse("a{{! single } brace }}b")?
+        .render(TemplateValues)?)
+
+
+// ---------------------------------------------------------------------------
+// Raw block tests
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _PropRawBlockContentIdentity is Property1[String]
+  """
+  For any generated raw body, `{{raw}}<body>{{end}}` renders as `<body>`.
+  """
+  fun name(): String => "Prop: raw block content is identity"
+
+  fun gen(): Generator[String] =>
+    _Generators.raw_body()
+
+  fun property(sample: String, h: PropertyHelper)? =>
+    let source = recover val "{{raw}}" + sample + "{{end}}" end
+    h.assert_eq[String](sample,
+      Template.parse(source)?.render(TemplateValues)?)
+
+
+class \nodoc\ iso _PropRawBlockSurroundingLiteralsPreserved
+  is Property1[String]
+  """
+  Literals before and after a raw block are preserved in the output.
+  """
+  fun name(): String => "Prop: raw block preserves surrounding literals"
+
+  fun gen(): Generator[String] =>
+    _Generators.raw_body()
+
+  fun property(sample: String, h: PropertyHelper)? =>
+    let source = recover val "before{{raw}}" + sample + "{{end}}after" end
+    let expected = recover val "before" + sample + "after" end
+    h.assert_eq[String](expected,
+      Template.parse(source)?.render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestRawBasic is UnitTest
+  fun name(): String => "Raw: basic raw block passes through delimiters"
+
+  fun apply(h: TestHelper)? =>
+    h.assert_eq[String]("{{ name }}",
+      Template.parse("{{raw}}{{ name }}{{end}}")?
+        .render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestRawWithTrim is UnitTest
+  fun name(): String => "Raw: trim markers on raw/end tags"
+
+  fun apply(h: TestHelper)? =>
+    // External trim: left-trim on raw strips preceding whitespace
+    h.assert_eq[String]("beforecontent after",
+      Template.parse("before   {{- raw }}content{{end}} after")?
+        .render(TemplateValues)?)
+    // External trim: right-trim on end strips following whitespace
+    h.assert_eq[String]("before contentafter",
+      Template.parse("before {{raw}}content{{end -}}   after")?
+        .render(TemplateValues)?)
+    // Internal trim: right-trim on raw lstrips content
+    h.assert_eq[String]("content",
+      Template.parse("{{raw -}}   content{{end}}")?
+        .render(TemplateValues)?)
+    // Internal trim: left-trim on end rstrips content
+    h.assert_eq[String]("content",
+      Template.parse("{{raw}}content   {{- end}}")?
+        .render(TemplateValues)?)
+    // Both internal trims
+    h.assert_eq[String]("content",
+      Template.parse("{{raw -}}   content   {{- end}}")?
+        .render(TemplateValues)?)
+    // All four trims
+    h.assert_eq[String]("content",
+      Template.parse("   {{- raw -}}   content   {{- end -}}   ")?
+        .render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestRawWithTemplateDelimiters is UnitTest
+  fun name(): String => "Raw: template syntax passes through literally"
+
+  fun apply(h: TestHelper)? =>
+    // Note: {{ end }} cannot appear inside raw content because it closes the
+    // raw block. Other template syntax passes through fine.
+    h.assert_eq[String]("{{ if flag }}yes{{ else }}no",
+      Template.parse(
+        "{{raw}}{{ if flag }}yes{{ else }}no{{end}}")?
+        .render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestRawInsideIf is UnitTest
+  fun name(): String => "Raw: raw block inside if body"
+
+  fun apply(h: TestHelper)? =>
+    let values = TemplateValues
+    values("show") = "yes"
+    h.assert_eq[String]("{{ x }}",
+      Template.parse(
+        "{{ if show }}{{raw}}{{ x }}{{end}}{{ end }}")?
+        .render(values)?)
+    // When condition is false, raw content not rendered
+    h.assert_eq[String]("",
+      Template.parse(
+        "{{ if show }}{{raw}}{{ x }}{{end}}{{ end }}")?
+        .render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestRawInsideLoop is UnitTest
+  fun name(): String => "Raw: raw block inside loop body"
+
+  fun apply(h: TestHelper)? =>
+    let values = TemplateValues
+    values("items") = TemplateValue(
+      [TemplateValue("a"); TemplateValue("b")])
+    h.assert_eq[String]("{{ x }}{{ x }}",
+      Template.parse(
+        "{{ for item in items }}{{raw}}{{ x }}{{end}}{{ end }}")?
+        .render(values)?)
+
+
+class \nodoc\ iso _TestRawInsideElse is UnitTest
+  fun name(): String => "Raw: raw block inside else branch"
+
+  fun apply(h: TestHelper)? =>
+    h.assert_eq[String]("{{ fallback }}",
+      Template.parse(
+        "{{ if missing }}yes{{ else }}{{raw}}{{ fallback }}{{end}}{{ end }}")?
+        .render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestRawBeforeExtends is UnitTest
+  fun name(): String => "Raw: raw block before extends prevents extends"
+
+  fun apply(h: TestHelper) =>
+    h.assert_error({()? =>
+      let partials = recover val
+        let m = Map[String, String]
+        m("base") = "base content"
+        m
+      end
+      let ctx = TemplateContext(where partials' = partials)
+      Template.parse(
+        "{{raw}}literal{{end}}{{ extends \"base\" }}", ctx)?
+    })
+
+
+class \nodoc\ iso _TestRawAdjacent is UnitTest
+  fun name(): String => "Raw: multiple adjacent raw blocks"
+
+  fun apply(h: TestHelper)? =>
+    h.assert_eq[String]("{{ a }}{{ b }}",
+      Template.parse(
+        "{{raw}}{{ a }}{{end}}{{raw}}{{ b }}{{end}}")?
+        .render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestRawBetweenLiterals is UnitTest
+  fun name(): String => "Raw: raw block between regular literals"
+
+  fun apply(h: TestHelper)? =>
+    h.assert_eq[String]("before{{ x }}after",
+      Template.parse("before{{raw}}{{ x }}{{end}}after")?
+        .render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestRawEmpty is UnitTest
+  fun name(): String => "Raw: empty raw block"
+
+  fun apply(h: TestHelper)? =>
+    h.assert_eq[String]("beforeafter",
+      Template.parse("before{{raw}}{{end}}after")?
+        .render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestRawUnclosed is UnitTest
+  fun name(): String => "Raw: unclosed raw block is a parse error"
+
+  fun apply(h: TestHelper) =>
+    h.assert_error({()? =>
+      Template.parse("{{raw}}content without end")?
+    })
+    // Missing end entirely
+    h.assert_error({()? =>
+      Template.parse("{{raw}}{{ stuff }}")?
+    })
+
+
+class \nodoc\ iso _TestRawMinimal is UnitTest
+  fun name(): String => "Raw: minimal forms with and without whitespace"
+
+  fun apply(h: TestHelper)? =>
+    // No whitespace
+    h.assert_eq[String]("x",
+      Template.parse("{{raw}}x{{end}}")?.render(TemplateValues)?)
+    // Whitespace in tags
+    h.assert_eq[String]("x",
+      Template.parse("{{ raw }}x{{ end }}")?.render(TemplateValues)?)
+    // Whitespace in raw tag only
+    h.assert_eq[String]("x",
+      Template.parse("{{ raw }}x{{end}}")?.render(TemplateValues)?)
+
+
+class \nodoc\ iso _TestRawWithBraces is UnitTest
+  fun name(): String => "Raw: content with single braces and non-end blocks"
+
+  fun apply(h: TestHelper)? =>
+    // Single braces pass through
+    h.assert_eq[String]("a{b}c",
+      Template.parse("{{raw}}a{b}c{{end}}")?.render(TemplateValues)?)
+    // Non-end {{ }} blocks inside raw are literal
+    h.assert_eq[String]("{{ if x }}",
+      Template.parse("{{raw}}{{ if x }}{{end}}")?.render(TemplateValues)?)
+    // {{ for ... }} inside raw is literal
+    h.assert_eq[String]("{{ for i in items }}{{ i }}",
+      Template.parse("{{raw}}{{ for i in items }}{{ i }}{{end}}")?
         .render(TemplateValues)?)
 
 

--- a/templates/template.pony
+++ b/templates/template.pony
@@ -36,6 +36,12 @@ blocks. Supported block types:
   or both can be used independently: `{{- x -}}`. Whitespace includes spaces,
   tabs, and newlines. Useful for generating indentation-sensitive output like
   YAML without unwanted blank lines from control flow tags.
+* **Raw / literal blocks**: `{{raw}}...{{end}}` emits everything between the
+  tags as literal text, without interpreting `{{ }}` sequences. Useful when the
+  template output itself contains delimiter syntax (e.g., generating Mustache
+  templates or documentation about this library). Trim markers work on both tags:
+  `{{- raw -}}...{{- end -}}`. The first `{{ end }}` closes the raw block, so
+  literal `{{ end }}` cannot appear inside raw content.
 * **Comments**: `{{! ... }}` is ignored during rendering. Everything between `!`
   and `}}` is discarded. Comments can appear anywhere a normal block can appear,
   and trim markers work as expected: `{{!- comment -}}`.
@@ -267,6 +273,7 @@ class box _BlockScan
   let left_trim: Bool
   let right_trim: Bool
   let is_comment: Bool
+  let is_raw: Bool
 
   new box create(
     stmt_source': String,
@@ -274,7 +281,8 @@ class box _BlockScan
     end_pos': ISize,
     left_trim': Bool,
     right_trim': Bool,
-    is_comment': Bool
+    is_comment': Bool,
+    is_raw': Bool = false
   ) =>
     stmt_source = stmt_source'
     start_pos = start_pos'
@@ -282,6 +290,7 @@ class box _BlockScan
     left_trim = left_trim'
     right_trim = right_trim'
     is_comment = is_comment'
+    is_raw = is_raw'
 
 
 class val Template
@@ -314,8 +323,9 @@ class val Template
     var trim_next_literal: Bool = false
     var prev_end: ISize = 0
     while prev_end < source.size().isize() do
+      let scan_result = _scan_next_block(source, prev_end)?
       let block =
-        match _scan_next_block(source, prev_end)
+        match scan_result
         | let b: _BlockScan => b
         | None => break
         end
@@ -331,6 +341,16 @@ class val Template
       trim_next_literal = block.right_trim
 
       if block.is_comment then
+        prev_end = block.end_pos + 2
+        continue
+      end
+
+      if block.is_raw then
+        let raw_content = block.stmt_source
+        if raw_content.size() > 0 then
+          current_parts.push((_Literal, raw_content))
+        end
+        first_stmt = false
         prev_end = block.end_pos + 2
         continue
       end
@@ -533,8 +553,9 @@ class val Template
   fun tag _check_extends(source: String): (String | None)? =>
     var search_from: ISize = 0
     while search_from < source.size().isize() do
+      let scan_result' = _scan_next_block(source, search_from)?
       let block =
-        match _scan_next_block(source, search_from)
+        match scan_result'
         | let b: _BlockScan => b
         | None => return None
         end
@@ -543,6 +564,8 @@ class val Template
         search_from = block.end_pos + 2
         continue
       end
+
+      if block.is_raw then return None end
 
       match _StmtParser.parse(block.stmt_source)?
       | let ext: _ExtendsNode => return ext.name
@@ -617,17 +640,21 @@ class val Template
   fun tag _scan_next_block(
     source: String,
     from: ISize
-  ): (_BlockScan | None) =>
+  ): (_BlockScan | None)? =>
     """
     Scan for the next `{{ }}` block starting from `from`. Returns a
     `_BlockScan` with the extracted statement content and metadata, or
     `None` if no more blocks are found (missing `{{` or `}}`).
+    Errors on unclosed raw blocks.
     """
     let start_pos =
       try source.find("{{" where offset = from)?
       else return None
       end
     let is_comment = _is_comment_open(source, start_pos)
+    if (not is_comment) and _is_raw_open(source, start_pos) then
+      return _scan_raw_block(source, start_pos)?
+    end
     // Comments don't use quote-aware scanning — a `"` inside a comment
     // body is literal text, not a string delimiter.
     let end_pos =
@@ -681,6 +708,135 @@ class val Template
       end
     end
     false
+
+  fun tag _is_raw_open(source: String, start_pos: ISize): Bool =>
+    """
+    Check whether the `{{ }}` block starting at `start_pos` is a raw block
+    opener. Peeks past `{{`, optional `-` trim marker, and optional whitespace
+    to see if the next content is the `raw` keyword followed by a word
+    boundary (space, tab, `-`, or `}`).
+    """
+    var i = (start_pos + 2).usize()
+    let limit = source.size()
+    // Skip optional trim marker
+    try if source(i)? == '-' then i = i + 1 end end
+    // Skip whitespace
+    while i < limit do
+      try
+        let c = source(i)?
+        if (c == ' ') or (c == '\t') then i = i + 1
+        else break
+        end
+      else return false
+      end
+    end
+    // Check for "raw" keyword
+    if (i + 3) > limit then return false end
+    try
+      if (source(i)? != 'r')
+        or (source(i + 1)? != 'a')
+        or (source(i + 2)? != 'w')
+      then
+        return false
+      end
+    else return false
+    end
+    // Check word boundary: next char must be space, tab, -, or }
+    if (i + 3) == limit then return false end
+    try
+      let c = source(i + 3)?
+      (c == ' ') or (c == '\t') or (c == '-') or (c == '}')
+    else false
+    end
+
+  fun tag _find_raw_end(
+    source: String,
+    from: ISize
+  ): (ISize, ISize, Bool, Bool)? =>
+    """
+    Scan forward from `from` looking for `{{ end }}` (with optional trim/
+    whitespace). Returns `(start_pos, end_pos, left_trim, right_trim)` of the
+    closing `{{end}}` tag, or errors if not found.
+    """
+    var search = from
+    while search < source.size().isize() do
+      let open_pos = source.find("{{" where offset = search)?
+      let close_pos = source.find("}}" where offset = open_pos + 2)?
+
+      // Extract content between {{ and }}
+      let lt =
+        try source((open_pos + 2).usize())? == '-'
+        else false
+        end
+      let content_start: ISize =
+        if lt then open_pos + 3 else open_pos + 2 end
+      let rt =
+        try
+          (close_pos > content_start)
+            and (source((close_pos - 1).usize())? == '-')
+        else false
+        end
+      let content_end: ISize =
+        if rt then close_pos - 1 else close_pos end
+
+      let inner = source.substring(content_start, content_end)
+      inner.strip()
+
+      if inner == "end" then
+        return (open_pos, close_pos, lt, rt)
+      end
+
+      search = close_pos + 2
+    end
+    error
+
+  fun tag _scan_raw_block(source: String, start_pos: ISize): _BlockScan? =>
+    """
+    Scan a `{{raw}}...{{end}}` raw block starting at `start_pos`. Returns a
+    `_BlockScan` with `is_raw = true` whose `stmt_source` is the literal
+    content between the raw open tag and the matching `{{end}}`.
+    """
+    // Find closing }} of the {{raw}} tag
+    let raw_close =
+      try source.find("}}" where offset = start_pos + 2)?
+      else error
+      end
+
+    // Determine trim flags on raw open tag
+    let outer_left_trim =
+      try source((start_pos + 2).usize())? == '-'
+      else false
+      end
+    let raw_stmt_start: ISize =
+      if outer_left_trim then start_pos + 3 else start_pos + 2 end
+    let raw_right_trim =
+      try
+        (raw_close > raw_stmt_start)
+          and (source((raw_close - 1).usize())? == '-')
+      else false
+      end
+
+    // Find matching {{end}}
+    let content_start = raw_close + 2
+    (let end_open, let end_close, let end_left_trim, let outer_right_trim) =
+      _find_raw_end(source, content_start)?
+
+    // Extract raw content between raw close and end open
+    var content = source.substring(content_start, end_open)
+
+    // Apply internal trim: raw open's right-trim → lstrip content,
+    // end tag's left-trim → rstrip content
+    if raw_right_trim then content.lstrip() end
+    if end_left_trim then content.rstrip() end
+
+    _BlockScan(
+      consume content,
+      start_pos,
+      end_close,
+      outer_left_trim,
+      outer_right_trim,
+      false,
+      true)
 
   fun tag _find_close_delim(source: String, from: ISize): ISize? =>
     """


### PR DESCRIPTION
Raw blocks (`{{raw}}...{{end}}`) let users output literal `{{ }}` delimiters without the engine interpreting them. This matters when the template output itself contains delimiter syntax — e.g., generating Mustache templates, or documentation about this library.

Detection happens at the block scanner level, not the statement parser — once `{{raw}}` is detected, all subsequent `{{ }}` sequences are treated as literal text until `{{end}}`. Same approach as comments. Trim markers work on both tags.

The first `{{ end }}` closes the raw block; literal `{{ end }}` cannot appear inside raw content (same class of limitation as `}}` inside comments). Unclosed raw blocks are parse errors.

Making `_scan_next_block` partial was required for the unclosed-raw error path. A ponyc compiler crash (assertion in `pass_expr`) was worked around by separating the partial call from the `match` expression at both call sites.

Design: https://github.com/ponylang/templates/discussions/38