### PR TITLE
Add HTML context state machine and escaping functions

### DIFF
--- a/templates/_test.pony
+++ b/templates/_test.pony
@@ -204,6 +204,48 @@ actor \nodoc\ Main is TestList
     // from_file test (Step 8)
     test(_TestFromFile)
 
+    // HTML context state machine tests
+    test(_TestContextText)
+    test(_TestContextTag)
+    test(_TestContextAttrDq)
+    test(_TestContextAttrSq)
+    test(_TestContextUnqAttrError)
+    test(_TestContextComment)
+    test(_TestContextScript)
+    test(_TestContextStyle)
+    test(_TestContextRcdata)
+    test(_TestContextUrlAttr)
+    test(_TestContextJsAttr)
+    test(_TestContextCssAttr)
+    test(_TestContextClone)
+    test(_TestContextBranchConsistency)
+    test(_TestContextCaseInsensitiveTags)
+    test(_TestContextScriptWithAttrs)
+    test(_TestContextClosingTag)
+    test(_TestContextCaseInsensitiveClose)
+    test(_TestContextCloseTagWhitespace)
+    test(Property1UnitTest[String](_PropContextTextRoundtrip))
+
+    // HTML escape function tests
+    test(_TestEscapeHtmlText)
+    test(_TestEscapeHtmlAttr)
+    test(_TestEscapeUrl)
+    test(_TestEscapeUrlPercentEncoding)
+    test(_TestEscapeUrlNoFalsePositive)
+    test(_TestEscapeJs)
+    test(_TestEscapeJsControlChars)
+    test(_TestEscapeCss)
+    test(_TestEscapeCssFormat)
+    test(_TestEscapeComment)
+    test(_TestEscapeRcdata)
+    test(_TestEscapeErrorContext)
+    test(Property1UnitTest[String](_PropEscapeHtmlNoUnescapedChars))
+    test(Property1UnitTest[String](_PropEscapeRcdataNoUnescapedChars))
+
+    // RenderableValue tests
+    test(_TestHtmlEscapingRenderer)
+    test(_TestNoEscapeRenderer)
+
 
 // ---------------------------------------------------------------------------
 // Generators (Step 2)
@@ -3370,3 +3412,479 @@ class \nodoc\ iso _TestFromFile is UnitTest
         "templates/_nonexistent.txt")
       Template.from_file(bad_path)?
     })
+
+
+// ---------------------------------------------------------------------------
+// HTML context state machine tests
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _TestContextText is UnitTest
+  fun name(): String => "HtmlContext: text is default state"
+
+  fun apply(h: TestHelper) =>
+    let t = _HtmlContextTracker
+    h.assert_is[_HtmlContext](_CtxText, t.context())
+    t.feed("hello world")
+    h.assert_is[_HtmlContext](_CtxText, t.context())
+
+class \nodoc\ iso _TestContextTag is UnitTest
+  fun name(): String => "HtmlContext: inside tag is error"
+
+  fun apply(h: TestHelper) =>
+    let t = _HtmlContextTracker
+    t.feed("<div")
+    h.assert_is[_HtmlContext](_CtxError, t.context())
+
+class \nodoc\ iso _TestContextAttrDq is UnitTest
+  fun name(): String => "HtmlContext: double-quoted attr value"
+
+  fun apply(h: TestHelper) =>
+    let t = _HtmlContextTracker
+    t.feed("<div class=\"")
+    h.assert_is[_HtmlContext](_CtxHtmlAttr, t.context())
+    t.feed("foo\"")
+    // After closing quote, back in tag
+    h.assert_is[_HtmlContext](_CtxError, t.context())
+
+class \nodoc\ iso _TestContextAttrSq is UnitTest
+  fun name(): String => "HtmlContext: single-quoted attr value"
+
+  fun apply(h: TestHelper) =>
+    let t = _HtmlContextTracker
+    t.feed("<div class='")
+    h.assert_is[_HtmlContext](_CtxHtmlAttr, t.context())
+
+class \nodoc\ iso _TestContextUnqAttrError is UnitTest
+  fun name(): String => "HtmlContext: unquoted attr value is error"
+
+  fun apply(h: TestHelper) =>
+    let t = _HtmlContextTracker
+    t.feed("<div class=")
+    // Before attr val, still error
+    h.assert_is[_HtmlContext](_CtxError, t.context())
+    t.feed("x")
+    // In unquoted attr val — error context
+    h.assert_is[_HtmlContext](_CtxError, t.context())
+
+class \nodoc\ iso _TestContextComment is UnitTest
+  fun name(): String => "HtmlContext: HTML comment"
+
+  fun apply(h: TestHelper) =>
+    let t = _HtmlContextTracker
+    t.feed("<!--")
+    t.feed_close_tag("<!--")
+    h.assert_is[_HtmlContext](_CtxComment, t.context())
+    t.feed(" comment text -->")
+    t.feed_close_tag(" comment text -->")
+    h.assert_is[_HtmlContext](_CtxText, t.context())
+
+class \nodoc\ iso _TestContextScript is UnitTest
+  fun name(): String => "HtmlContext: script tag"
+
+  fun apply(h: TestHelper) =>
+    let t = _HtmlContextTracker
+    t.feed("<script>")
+    h.assert_is[_HtmlContext](_CtxScript, t.context())
+    t.feed("var x = 1;")
+    t.feed_close_tag("var x = 1;")
+    h.assert_is[_HtmlContext](_CtxScript, t.context())
+    let closing = "</script>"
+    t.feed(closing)
+    t.feed_close_tag(closing)
+    h.assert_is[_HtmlContext](_CtxText, t.context())
+
+class \nodoc\ iso _TestContextStyle is UnitTest
+  fun name(): String => "HtmlContext: style tag"
+
+  fun apply(h: TestHelper) =>
+    let t = _HtmlContextTracker
+    t.feed("<style>")
+    h.assert_is[_HtmlContext](_CtxStyle, t.context())
+    let closing = "</style>"
+    t.feed(closing)
+    t.feed_close_tag(closing)
+    h.assert_is[_HtmlContext](_CtxText, t.context())
+
+class \nodoc\ iso _TestContextRcdata is UnitTest
+  fun name(): String => "HtmlContext: title/textarea RCDATA"
+
+  fun apply(h: TestHelper) =>
+    let t = _HtmlContextTracker
+    t.feed("<title>")
+    h.assert_is[_HtmlContext](_CtxRcdata, t.context())
+    let closing = "</title>"
+    t.feed(closing)
+    t.feed_close_tag(closing)
+    h.assert_is[_HtmlContext](_CtxText, t.context())
+
+class \nodoc\ iso _TestContextUrlAttr is UnitTest
+  fun name(): String => "HtmlContext: URL attributes"
+
+  fun apply(h: TestHelper) =>
+    let t = _HtmlContextTracker
+    t.feed("<a href=\"")
+    h.assert_is[_HtmlContext](_CtxUrlAttr, t.context())
+
+class \nodoc\ iso _TestContextJsAttr is UnitTest
+  fun name(): String => "HtmlContext: JS event attributes"
+
+  fun apply(h: TestHelper) =>
+    let t = _HtmlContextTracker
+    t.feed("<div onclick=\"")
+    h.assert_is[_HtmlContext](_CtxJsAttr, t.context())
+
+class \nodoc\ iso _TestContextCssAttr is UnitTest
+  fun name(): String => "HtmlContext: style attribute"
+
+  fun apply(h: TestHelper) =>
+    let t = _HtmlContextTracker
+    t.feed("<div style=\"")
+    h.assert_is[_HtmlContext](_CtxCssAttr, t.context())
+
+class \nodoc\ iso _TestContextClone is UnitTest
+  fun name(): String => "HtmlContext: clone preserves state"
+
+  fun apply(h: TestHelper) =>
+    let t: _HtmlContextTracker ref = _HtmlContextTracker
+    t.feed("<div class=\"")
+    let t2 = t.clone()
+    h.assert_true(t.eq(t2))
+    t.feed("foo\"")
+    // Original advanced, clone stayed
+    h.assert_false(t.eq(t2))
+    h.assert_is[_HtmlContext](_CtxHtmlAttr, t2.context())
+
+class \nodoc\ iso _TestContextBranchConsistency is UnitTest
+  fun name(): String => "HtmlContext: branch consistency check"
+
+  fun apply(h: TestHelper) =>
+    // Both branches end in text — consistent
+    let t1: _HtmlContextTracker ref = _HtmlContextTracker
+    t1.feed("<p>")
+    let t2 = t1.clone()
+    t1.feed("hello")
+    t2.feed("world")
+    h.assert_true(t1.eq(t2))
+
+    // One branch opens a tag — inconsistent
+    let t3: _HtmlContextTracker ref = _HtmlContextTracker
+    t3.feed("<p>")
+    let t4 = t3.clone()
+    t3.feed("<div>")
+    t4.feed("<a href=\"")
+    h.assert_false(t3.eq(t4))
+
+class \nodoc\ iso _TestContextCaseInsensitiveTags is UnitTest
+  fun name(): String => "HtmlContext: case-insensitive tag matching"
+
+  fun apply(h: TestHelper) =>
+    let t1 = _HtmlContextTracker
+    t1.feed("<SCRIPT>")
+    h.assert_is[_HtmlContext](_CtxScript, t1.context())
+
+    let t2 = _HtmlContextTracker
+    t2.feed("<Script>")
+    h.assert_is[_HtmlContext](_CtxScript, t2.context())
+
+    let t3 = _HtmlContextTracker
+    t3.feed("<STYLE>")
+    h.assert_is[_HtmlContext](_CtxStyle, t3.context())
+
+    let t4 = _HtmlContextTracker
+    t4.feed("<TITLE>")
+    h.assert_is[_HtmlContext](_CtxRcdata, t4.context())
+
+class \nodoc\ iso _TestContextScriptWithAttrs is UnitTest
+  fun name(): String => "HtmlContext: script tag with attributes"
+
+  fun apply(h: TestHelper) =>
+    let t = _HtmlContextTracker
+    t.feed("<script type=\"text/javascript\">")
+    h.assert_is[_HtmlContext](_CtxScript, t.context())
+
+class \nodoc\ iso _TestContextClosingTag is UnitTest
+  fun name(): String => "HtmlContext: closing tag returns to text"
+
+  fun apply(h: TestHelper) =>
+    let t = _HtmlContextTracker
+    t.feed("<div>hello</div>")
+    h.assert_is[_HtmlContext](_CtxText, t.context())
+
+class \nodoc\ iso _TestContextCaseInsensitiveClose is UnitTest
+  fun name(): String => "HtmlContext: case-insensitive closing tags"
+
+  fun apply(h: TestHelper) =>
+    let t = _HtmlContextTracker
+    t.feed("<script>")
+    h.assert_is[_HtmlContext](_CtxScript, t.context())
+    let closing = "</SCRIPT>"
+    t.feed(closing)
+    t.feed_close_tag(closing)
+    h.assert_is[_HtmlContext](_CtxText, t.context())
+
+class \nodoc\ iso _TestContextCloseTagWhitespace is UnitTest
+  fun name(): String => "HtmlContext: closing tag with whitespace before >"
+
+  fun apply(h: TestHelper) =>
+    // </script > is a valid closing tag per the HTML spec
+    let t1 = _HtmlContextTracker
+    t1.feed("<script>")
+    let closing1 = "</script >"
+    t1.feed(closing1)
+    t1.feed_close_tag(closing1)
+    h.assert_is[_HtmlContext](_CtxText, t1.context())
+
+    // Multiple whitespace chars
+    let t2 = _HtmlContextTracker
+    t2.feed("<style>")
+    let closing2 = "</style\t\n >"
+    t2.feed(closing2)
+    t2.feed_close_tag(closing2)
+    h.assert_is[_HtmlContext](_CtxText, t2.context())
+
+    // No whitespace still works
+    let t3 = _HtmlContextTracker
+    t3.feed("<script>")
+    let closing3 = "</script>"
+    t3.feed(closing3)
+    t3.feed_close_tag(closing3)
+    h.assert_is[_HtmlContext](_CtxText, t3.context())
+
+class \nodoc\ iso _PropContextTextRoundtrip is Property1[String]
+  fun name(): String => "HtmlContext: text without < stays in text state"
+
+  fun gen(): Generator[String] =>
+    // Generate strings of lowercase letters — no < to stay in text state
+    Generators.ascii(0, 50)
+      .filter({(s: String): (String, Bool) =>
+        var ok = true
+        for c in s.values() do
+          if c == '<' then ok = false; break end
+        end
+        (s, ok)
+      })
+
+  fun property(arg1: String, h: PropertyHelper) =>
+    let t = _HtmlContextTracker
+    t.feed(arg1)
+    h.assert_is[_HtmlContext](_CtxText, t.context())
+
+
+// ---------------------------------------------------------------------------
+// HTML escape function tests
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _TestEscapeHtmlText is UnitTest
+  fun name(): String => "HtmlEscape: text escapes all five chars"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[String]("&amp;&lt;&gt;&#34;&#39;",
+      _HtmlEscape.html_text("&<>\"'"))
+    h.assert_eq[String]("hello", _HtmlEscape.html_text("hello"))
+    h.assert_eq[String]("", _HtmlEscape.html_text(""))
+    h.assert_eq[String]("a&amp;b&lt;c", _HtmlEscape.html_text("a&b<c"))
+
+class \nodoc\ iso _TestEscapeHtmlAttr is UnitTest
+  fun name(): String => "HtmlEscape: attr uses same escaping as text"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[String](_HtmlEscape.html_text("a<b"),
+      _HtmlEscape.html_attr("a<b"))
+
+class \nodoc\ iso _TestEscapeUrl is UnitTest
+  fun name(): String => "HtmlEscape: URL filters dangerous schemes"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[String]("#ZgotmplZ",
+      _HtmlEscape.url_attr("javascript:alert(1)"))
+    h.assert_eq[String]("#ZgotmplZ",
+      _HtmlEscape.url_attr("vbscript:run"))
+    h.assert_eq[String]("#ZgotmplZ",
+      _HtmlEscape.url_attr("data:text/html,<script>"))
+    // Safe URLs pass through (with encoding)
+    let result = _HtmlEscape.url_attr("https://example.com")
+    h.assert_true(result.contains("example.com"))
+    h.assert_false(result.contains("#ZgotmplZ"))
+
+class \nodoc\ iso _TestEscapeJs is UnitTest
+  fun name(): String => "HtmlEscape: JS escapes special chars"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[String]("\\\\", _HtmlEscape.js_string("\\"))
+    h.assert_eq[String]("\\'", _HtmlEscape.js_string("'"))
+    h.assert_eq[String]("\\\"", _HtmlEscape.js_string("\""))
+    h.assert_eq[String]("\\x3c", _HtmlEscape.js_string("<"))
+    h.assert_eq[String]("\\x3e", _HtmlEscape.js_string(">"))
+    h.assert_eq[String]("\\x26", _HtmlEscape.js_string("&"))
+    h.assert_eq[String]("hello", _HtmlEscape.js_string("hello"))
+
+class \nodoc\ iso _TestEscapeCss is UnitTest
+  fun name(): String => "HtmlEscape: CSS escapes unsafe chars"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[String]("hello", _HtmlEscape.css_value("hello"))
+    // Colon should be escaped
+    let result = _HtmlEscape.css_value(":")
+    h.assert_false(result == ":")
+
+class \nodoc\ iso _TestEscapeComment is UnitTest
+  fun name(): String => "HtmlEscape: comment strips dashes"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[String]("ab", _HtmlEscape.comment("a--b"))
+    h.assert_eq[String]("hello", _HtmlEscape.comment("hello"))
+    h.assert_eq[String]("", _HtmlEscape.comment("--"))
+
+class \nodoc\ iso _TestEscapeRcdata is UnitTest
+  fun name(): String => "HtmlEscape: RCDATA escapes < and &"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[String]("&amp;&lt;", _HtmlEscape.rcdata("&<"))
+    h.assert_eq[String]("hello", _HtmlEscape.rcdata("hello"))
+    h.assert_eq[String]("a&amp;b&lt;c>d", _HtmlEscape.rcdata("a&b<c>d"))
+
+class \nodoc\ iso _TestEscapeUrlPercentEncoding is UnitTest
+  fun name(): String => "HtmlEscape: URL percent-encodes special chars"
+
+  fun apply(h: TestHelper) =>
+    // Space should be percent-encoded, result then HTML-entity-encoded
+    let result = _HtmlEscape.url_attr("hello world")
+    h.assert_true(result.contains("%20"))
+    h.assert_false(result.contains(" "))
+
+class \nodoc\ iso _TestEscapeUrlNoFalsePositive is UnitTest
+  fun name(): String => "HtmlEscape: URL allows data: in path/query"
+
+  fun apply(h: TestHelper) =>
+    // "data:" in a query parameter should not be blocked
+    let result = _HtmlEscape.url_attr("https://example.com/?q=data:foo")
+    h.assert_false(result == "#ZgotmplZ")
+
+class \nodoc\ iso _TestEscapeJsControlChars is UnitTest
+  fun name(): String => "HtmlEscape: JS escapes control and high bytes"
+
+  fun apply(h: TestHelper) =>
+    // Control char (0x01) should be hex-escaped
+    let ctrl = recover val String.>push(0x01) end
+    let result = _HtmlEscape.js_string(ctrl)
+    h.assert_eq[String]("\\x01", result)
+    // High byte (0x80) should be hex-escaped
+    let high = recover val String.>push(0x80) end
+    let result2 = _HtmlEscape.js_string(high)
+    h.assert_eq[String]("\\x80", result2)
+
+class \nodoc\ iso _TestEscapeCssFormat is UnitTest
+  fun name(): String => "HtmlEscape: CSS escape format is \\HH<space>"
+
+  fun apply(h: TestHelper) =>
+    // Colon (0x3a) should be escaped as \3a followed by a space
+    h.assert_eq[String]("\\3a ", _HtmlEscape.css_value(":"))
+    // Semicolon (0x3b) should be escaped as \3b followed by a space
+    h.assert_eq[String]("\\3b ", _HtmlEscape.css_value(";"))
+
+class \nodoc\ iso _TestEscapeErrorContext is UnitTest
+  fun name(): String => "HtmlEscape: error context returns raw string"
+
+  fun apply(h: TestHelper) =>
+    let raw = "<script>alert('xss')</script>"
+    h.assert_eq[String](raw, _HtmlEscape.for_context(_CtxError, raw))
+
+class \nodoc\ iso _PropEscapeHtmlNoUnescapedChars is Property1[String]
+  fun name(): String =>
+    "HtmlEscape: html_text output never contains raw & < > \" '"
+
+  fun gen(): Generator[String] =>
+    Generators.ascii(0, 100)
+
+  fun property(arg1: String, h: PropertyHelper) =>
+    let escaped = _HtmlEscape.html_text(arg1)
+    // Check that no raw special chars remain (they should all be entities)
+    var i: USize = 0
+    while i < escaped.size() do
+      try
+        let c = escaped(i)?
+        match c
+        | '<' => h.fail("unescaped < at position " + i.string())
+        | '>' => h.fail("unescaped > at position " + i.string())
+        | '"' => h.fail("unescaped \" at position " + i.string())
+        | '\'' => h.fail("unescaped ' at position " + i.string())
+        | '&' =>
+          // & is OK only if it starts an entity
+          if not _starts_entity(escaped, i) then
+            h.fail("bare & at position " + i.string())
+          end
+        end
+      end
+      i = i + 1
+    end
+
+  fun _starts_entity(s: String, pos: USize): Bool =>
+    // Check for &amp; &lt; &gt; &#34; &#39;
+    if s.substring(pos.isize(), (pos + 5).isize()) == "&amp;" then
+      return true
+    end
+    if s.substring(pos.isize(), (pos + 4).isize()) == "&lt;" then
+      return true
+    end
+    if s.substring(pos.isize(), (pos + 4).isize()) == "&gt;" then
+      return true
+    end
+    if s.substring(pos.isize(), (pos + 5).isize()) == "&#34;" then
+      return true
+    end
+    if s.substring(pos.isize(), (pos + 5).isize()) == "&#39;" then
+      return true
+    end
+    false
+
+class \nodoc\ iso _PropEscapeRcdataNoUnescapedChars is Property1[String]
+  fun name(): String =>
+    "HtmlEscape: rcdata output never contains raw < or &"
+
+  fun gen(): Generator[String] =>
+    Generators.ascii(0, 100)
+
+  fun property(arg1: String, h: PropertyHelper) =>
+    let escaped = _HtmlEscape.rcdata(arg1)
+    var i: USize = 0
+    while i < escaped.size() do
+      try
+        let c = escaped(i)?
+        match c
+        | '<' => h.fail("unescaped < at position " + i.string())
+        | '&' =>
+          if not _starts_entity(escaped, i) then
+            h.fail("bare & at position " + i.string())
+          end
+        end
+      end
+      i = i + 1
+    end
+
+  fun _starts_entity(s: String, pos: USize): Bool =>
+    if s.substring(pos.isize(), (pos + 5).isize()) == "&amp;" then
+      return true
+    end
+    if s.substring(pos.isize(), (pos + 4).isize()) == "&lt;" then
+      return true
+    end
+    false
+
+
+// ---------------------------------------------------------------------------
+// RenderableValue tests
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _TestHtmlEscapingRenderer is UnitTest
+  fun name(): String => "RenderableValue: HtmlEscapingRenderer escapes"
+
+  fun apply(h: TestHelper) =>
+    let result = _HtmlEscapingRenderer.render(_CtxText, "<script>")
+    h.assert_eq[String]("&lt;script&gt;", result)
+
+class \nodoc\ iso _TestNoEscapeRenderer is UnitTest
+  fun name(): String => "RenderableValue: NoEscapeRenderer passes through"
+
+  fun apply(h: TestHelper) =>
+    let result = _NoEscapeRenderer.render(_CtxText, "<script>")
+    h.assert_eq[String]("<script>", result)

--- a/templates/html_context.pony
+++ b/templates/html_context.pony
@@ -1,0 +1,326 @@
+primitive _CtxText
+primitive _CtxHtmlAttr
+primitive _CtxUrlAttr
+primitive _CtxJsAttr
+primitive _CtxCssAttr
+primitive _CtxScript
+primitive _CtxStyle
+primitive _CtxComment
+primitive _CtxRcdata
+primitive _CtxError
+
+type _HtmlContext is
+  ( _CtxText | _CtxHtmlAttr | _CtxUrlAttr | _CtxJsAttr | _CtxCssAttr
+  | _CtxScript | _CtxStyle | _CtxComment | _CtxRcdata | _CtxError )
+
+
+primitive _StateText
+primitive _StateTag
+primitive _StateAttrName
+primitive _StateAfterAttrName
+primitive _StateBeforeAttrVal
+primitive _StateDqAttrVal
+primitive _StateSqAttrVal
+primitive _StateUnqAttrVal
+primitive _StateComment
+primitive _StateRcdata
+primitive _StateScript
+primitive _StateStyle
+
+type _HtmlState is
+  ( _StateText | _StateTag | _StateAttrName | _StateAfterAttrName
+  | _StateBeforeAttrVal | _StateDqAttrVal | _StateSqAttrVal
+  | _StateUnqAttrVal | _StateComment | _StateRcdata
+  | _StateScript | _StateStyle )
+
+
+class _HtmlContextTracker
+  """
+  Character-by-character HTML state machine that tracks position within HTML
+  structure. Used at both parse time (to validate insertion points) and render
+  time (to determine context-appropriate escaping).
+  """
+  var _state: _HtmlState = _StateText
+  var _tag_name: String ref = String
+  var _attr_name: String ref = String
+  var _tag_name_done: Bool = false
+
+  fun ref feed(text: String) =>
+    """
+    Advance the state machine through a chunk of literal text. Each chunk
+    should be a single literal segment between template insertion points.
+    After calling feed(), call feed_close_tag() with the same text to detect
+    closing tags for script, style, rcdata, and comment states. The two-pass
+    design assumes closing tags appear at chunk boundaries (guaranteed by the
+    template parser splitting at `{{ }}` delimiters).
+    """
+    var i: USize = 0
+    while i < text.size() do
+      try _feed_byte(text(i)?) end
+      i = i + 1
+    end
+
+  fun ref _feed_byte(c: U8) =>
+    match _state
+    | _StateText => _in_text(c)
+    | _StateTag => _in_tag(c)
+    | _StateAttrName => _in_attr_name(c)
+    | _StateAfterAttrName => _in_after_attr_name(c)
+    | _StateBeforeAttrVal => _in_before_attr_val(c)
+    | _StateDqAttrVal => if c == '"' then _state = _StateTag end
+    | _StateSqAttrVal => if c == '\'' then _state = _StateTag end
+    | _StateUnqAttrVal => _in_unq_attr_val(c)
+    | _StateComment => _in_comment(c)
+    | _StateRcdata => _in_rcdata(c)
+    | _StateScript => _in_script(c)
+    | _StateStyle => _in_style(c)
+    end
+
+  fun ref _in_text(c: U8) =>
+    if c == '<' then
+      _tag_name = String
+      _tag_name_done = false
+      _state = _StateTag
+    end
+
+  fun ref _in_tag(c: U8) =>
+    if c == '>' then
+      _transition_after_tag()
+    elseif _is_ws(c) then
+      _tag_name_done = true
+    elseif c == '/' then
+      _tag_name_done = true
+    elseif not _tag_name_done then
+      // Still building tag name
+      if c == '!' then
+        _tag_name.push(c)
+      else
+        _tag_name.push(_lower(c))
+      end
+      if _starts_comment() then
+        _state = _StateComment
+      end
+    else
+      // After tag name — start of attribute
+      _attr_name = String
+      _attr_name.push(_lower(c))
+      _state = _StateAttrName
+    end
+
+  fun _starts_comment(): Bool =>
+    try
+      (_tag_name.size() >= 3)
+        and (_tag_name(0)? == '!')
+        and (_tag_name(1)? == '-')
+        and (_tag_name(2)? == '-')
+    else false
+    end
+
+  fun ref _in_attr_name(c: U8) =>
+    if c == '=' then
+      _state = _StateBeforeAttrVal
+    elseif c == '>' then
+      _transition_after_tag()
+    elseif _is_ws(c) then
+      _state = _StateAfterAttrName
+    elseif _is_name_char(c) then
+      _attr_name.push(_lower(c))
+    else
+      _state = _StateTag
+    end
+
+  fun ref _in_after_attr_name(c: U8) =>
+    if c == '=' then
+      _state = _StateBeforeAttrVal
+    elseif c == '>' then
+      _transition_after_tag()
+    elseif _is_ws(c) then
+      None
+    else
+      // New attribute without value
+      _attr_name = String
+      _attr_name.push(_lower(c))
+      _state = _StateAttrName
+    end
+
+  fun ref _in_before_attr_val(c: U8) =>
+    if c == '"' then
+      _state = _StateDqAttrVal
+    elseif c == '\'' then
+      _state = _StateSqAttrVal
+    elseif _is_ws(c) then
+      None
+    elseif c == '>' then
+      _transition_after_tag()
+    else
+      _state = _StateUnqAttrVal
+    end
+
+  fun ref _in_unq_attr_val(c: U8) =>
+    if _is_ws(c) then
+      _state = _StateTag
+    elseif c == '>' then
+      _transition_after_tag()
+    end
+
+  fun ref _in_comment(c: U8) =>
+    // No-op per byte. Closing "-->" is detected by feed_close_tag().
+    None
+
+  fun ref _in_rcdata(c: U8) =>
+    // No-op per byte. Closing tags are detected by feed_close_tag().
+    None
+
+  fun ref _in_script(c: U8) =>
+    // No-op per byte. Closing </script> is detected by feed_close_tag().
+    None
+
+  fun ref _in_style(c: U8) =>
+    // No-op per byte. Closing </style> is detected by feed_close_tag().
+    None
+
+  fun ref _transition_after_tag() =>
+    // _tag_name is already lowered during construction in _in_tag
+    if (_tag_name == "script") then
+      _state = _StateScript
+    elseif (_tag_name == "style") then
+      _state = _StateStyle
+    elseif (_tag_name == "title") or (_tag_name == "textarea") then
+      _state = _StateRcdata
+    else
+      _state = _StateText
+    end
+    _tag_name = String
+    _attr_name = String
+    _tag_name_done = false
+
+  fun ref feed_close_tag(text: String) =>
+    """
+    Scan literal text for closing tags that would change the state back
+    to text. Must be called after feed() for states that need closing tag
+    detection (script, style, rcdata).
+    """
+    match _state
+    | _StateScript =>
+      if _contains_close_tag(text, "script") then
+        _state = _StateText
+      end
+    | _StateStyle =>
+      if _contains_close_tag(text, "style") then
+        _state = _StateText
+      end
+    | _StateRcdata =>
+      if _contains_close_tag(text, "title")
+        or _contains_close_tag(text, "textarea")
+      then
+        _state = _StateText
+      end
+    | _StateComment =>
+      if text.contains("-->") then
+        _state = _StateText
+      end
+    end
+
+  fun _contains_close_tag(text: String, tag_name: String): Bool =>
+    // Look for </tag> case-insensitively, allowing optional whitespace
+    // before >. Per the HTML spec, </script > is a valid closing tag.
+    let lower = text.clone()
+    lower.lower_in_place()
+    let prefix = recover val
+      let s = String(tag_name.size() + 2)
+      s.append("</")
+      s.append(tag_name)
+      s
+    end
+    // Scan for the prefix, then check that only whitespace follows before >
+    var pos: USize = 0
+    try
+      while pos < lower.size() do
+        let remaining = lower.substring(pos.isize())
+        if remaining.at(prefix) then
+          var j = pos + prefix.size()
+          // Skip optional whitespace
+          while (j < lower.size()) and _is_ws(lower(j)?) do
+            j = j + 1
+          end
+          if (j < lower.size()) and (lower(j)? == '>') then
+            return true
+          end
+        end
+        pos = pos + 1
+      end
+    end
+    false
+
+  fun context(): _HtmlContext =>
+    """
+    Return the current escaping context based on state and attribute name.
+    """
+    match _state
+    | _StateText => _CtxText
+    | _StateDqAttrVal => _attr_context()
+    | _StateSqAttrVal => _attr_context()
+    | _StateUnqAttrVal => _CtxError
+    | _StateScript => _CtxScript
+    | _StateStyle => _CtxStyle
+    | _StateComment => _CtxComment
+    | _StateRcdata => _CtxRcdata
+    | _StateTag => _CtxError
+    | _StateAttrName => _CtxError
+    | _StateAfterAttrName => _CtxError
+    | _StateBeforeAttrVal => _CtxError
+    end
+
+  fun _attr_context(): _HtmlContext =>
+    if _is_url_attr() then _CtxUrlAttr
+    elseif _is_js_attr() then _CtxJsAttr
+    elseif _is_css_attr() then _CtxCssAttr
+    else _CtxHtmlAttr
+    end
+
+  fun _is_url_attr(): Bool =>
+    // _attr_name is already lowered during construction
+    (_attr_name == "href") or (_attr_name == "src") or (_attr_name == "action")
+      or (_attr_name == "formaction") or (_attr_name == "cite")
+      or (_attr_name == "data") or (_attr_name == "poster")
+
+  fun _is_js_attr(): Bool =>
+    // _attr_name is already lowered during construction
+    try
+      (_attr_name.size() >= 2)
+        and (_attr_name(0)? == 'o')
+        and (_attr_name(1)? == 'n')
+    else false
+    end
+
+  fun _is_css_attr(): Bool =>
+    // _attr_name is already lowered during construction
+    _attr_name == "style"
+
+  fun state(): _HtmlState => _state
+
+  fun clone(): _HtmlContextTracker ref^ =>
+    let c = _HtmlContextTracker
+    c._state = _state
+    c._tag_name = _tag_name.clone()
+    c._attr_name = _attr_name.clone()
+    c._tag_name_done = _tag_name_done
+    c
+
+  fun eq(other: _HtmlContextTracker box): Bool =>
+    (_state is other._state)
+      and (_tag_name == other._tag_name)
+      and (_attr_name == other._attr_name)
+      and (_tag_name_done == other._tag_name_done)
+
+  fun _is_ws(c: U8): Bool =>
+    (c == ' ') or (c == '\t') or (c == '\n') or (c == '\r')
+
+  fun _is_name_char(c: U8): Bool =>
+    ((c >= 'a') and (c <= 'z'))
+      or ((c >= 'A') and (c <= 'Z'))
+      or ((c >= '0') and (c <= '9'))
+      or (c == '-') or (c == '_')
+
+  fun _lower(c: U8): U8 =>
+    if (c >= 'A') and (c <= 'Z') then c + 32 else c end

--- a/templates/html_escape.pony
+++ b/templates/html_escape.pony
@@ -1,0 +1,228 @@
+primitive _HtmlEscape
+  fun for_context(context: _HtmlContext, raw: String): String =>
+    """
+    Apply context-appropriate escaping to the raw string.
+    """
+    match context
+    | _CtxText => html_text(raw)
+    | _CtxHtmlAttr => html_attr(raw)
+    | _CtxUrlAttr => url_attr(raw)
+    | _CtxJsAttr => js_string(raw)
+    | _CtxCssAttr => css_value(raw)
+    | _CtxScript => js_string(raw)
+    | _CtxStyle => css_value(raw)
+    | _CtxComment => comment(raw)
+    | _CtxRcdata => rcdata(raw)
+    | _CtxError => raw
+    end
+
+  fun html_text(raw: String): String val =>
+    """
+    Escape `& < > " '` to HTML entities.
+    """
+    recover val
+      let out = String(raw.size())
+      for c in raw.values() do
+        match c
+        | '&' => out.append("&amp;")
+        | '<' => out.append("&lt;")
+        | '>' => out.append("&gt;")
+        | '"' => out.append("&#34;")
+        | '\'' => out.append("&#39;")
+        else
+          out.push(c)
+        end
+      end
+      out
+    end
+
+  fun html_attr(raw: String): String =>
+    """
+    Escape for quoted attribute values. Same entities as html_text.
+    """
+    html_text(raw)
+
+  fun url_attr(raw: String): String =>
+    """
+    Filter dangerous URL schemes, then percent-encode special characters
+    for use in a quoted URL attribute value.
+
+    Blocks `javascript:`, `vbscript:`, and `data:` schemes by replacing
+    the entire value with `#ZgotmplZ` (following Go's convention).
+    """
+    let trimmed = raw.clone()
+    trimmed.lstrip()
+    let lower = trimmed.clone()
+    lower.lower_in_place()
+
+    if _has_dangerous_scheme(consume lower) then
+      return "#ZgotmplZ"
+    end
+
+    // Percent-encode characters that are unsafe in URL attribute context,
+    // then HTML-entity-encode the result for embedding in an attribute.
+    let url_encoded = _percent_encode(raw)
+    html_attr(url_encoded)
+
+  fun js_string(raw: String): String val =>
+    """
+    Escape for JavaScript string context. Escapes backslash, quotes,
+    angle brackets, and non-ASCII to `\\xNN` / `\\uNNNN`.
+    """
+    recover val
+      let out = String(raw.size())
+      for c in raw.values() do
+        match c
+        | '\\' => out.append("\\\\")
+        | '\'' => out.append("\\'")
+        | '"' => out.append("\\\"")
+        | '<' => out.append("\\x3c")
+        | '>' => out.append("\\x3e")
+        | '&' => out.append("\\x26")
+        | '\n' => out.append("\\n")
+        | '\r' => out.append("\\r")
+        | '\t' => out.append("\\t")
+        else
+          if c < 0x20 then
+            _hex_escape(out, c)
+          elseif c >= 0x80 then
+            _hex_escape(out, c)
+          else
+            out.push(c)
+          end
+        end
+      end
+      out
+    end
+
+  fun css_value(raw: String): String val =>
+    """
+    Escape for CSS value context. Escapes characters that could break out
+    of a CSS value or inject expressions.
+    """
+    recover val
+      let out = String(raw.size())
+      for c in raw.values() do
+        if _is_css_safe(c) then
+          out.push(c)
+        else
+          _css_escape(out, c)
+        end
+      end
+      out
+    end
+
+  fun comment(raw: String): String val =>
+    """
+    Escape for HTML comment context. Strips `--` sequences to prevent
+    premature comment termination.
+    """
+    recover val
+      let out = raw.clone()
+      while out.contains("--") do
+        out.replace("--", "")
+      end
+      out
+    end
+
+  fun rcdata(raw: String): String val =>
+    """
+    Escape for RCDATA context (title, textarea). Only `<` and `&` need
+    escaping.
+    """
+    recover val
+      let out = String(raw.size())
+      for c in raw.values() do
+        match c
+        | '&' => out.append("&amp;")
+        | '<' => out.append("&lt;")
+        else
+          out.push(c)
+        end
+      end
+      out
+    end
+
+  fun _has_dangerous_scheme(lower: String val): Bool =>
+    // Caller must pass a trimmed, lowered string.
+    (lower.substring(0, 11) == "javascript:")
+      or (lower.substring(0, 9) == "vbscript:")
+      or (lower.substring(0, 5) == "data:")
+
+  fun _percent_encode(raw: String): String val =>
+    recover val
+      let out = String(raw.size())
+      for c in raw.values() do
+        if _is_url_safe(c) then
+          out.push(c)
+        else
+          out.push('%')
+          out.push(_hex_digit((c >> 4) and 0x0F))
+          out.push(_hex_digit(c and 0x0F))
+        end
+      end
+      out
+    end
+
+  fun _is_url_safe(c: U8): Bool =>
+    ((c >= 'a') and (c <= 'z'))
+      or ((c >= 'A') and (c <= 'Z'))
+      or ((c >= '0') and (c <= '9'))
+      or (c == '-') or (c == '_') or (c == '.')
+      or (c == '~') or (c == '/') or (c == ':')
+      or (c == '?') or (c == '#') or (c == '[')
+      or (c == ']') or (c == '@') or (c == '!')
+      or (c == '$') or (c == '&') or (c == '\'')
+      or (c == '(') or (c == ')') or (c == '*')
+      or (c == '+') or (c == ',') or (c == ';')
+      or (c == '=') or (c == '%')
+
+  fun _hex_escape(out: String ref, c: U8) =>
+    out.append("\\x")
+    out.push(_hex_digit((c >> 4) and 0x0F))
+    out.push(_hex_digit(c and 0x0F))
+
+  fun _css_escape(out: String ref, c: U8) =>
+    out.push('\\')
+    out.push(_hex_digit((c >> 4) and 0x0F))
+    out.push(_hex_digit(c and 0x0F))
+    out.push(' ')
+
+  fun _is_css_safe(c: U8): Bool =>
+    ((c >= 'a') and (c <= 'z'))
+      or ((c >= 'A') and (c <= 'Z'))
+      or ((c >= '0') and (c <= '9'))
+      or (c == ' ') or (c == '_') or (c == '-')
+      or (c == '.') or (c == ',') or (c == '/')
+
+  fun _hex_digit(n: U8): U8 =>
+    if n < 10 then '0' + n
+    else ('a' - 10) + n
+    end
+
+
+interface val _RenderableValue
+  """
+  Determines how a template value is rendered within an HTML context.
+  The renderer passes the current HTML context and the raw string value;
+  the implementation decides whether and how to escape.
+  """
+  fun val render(context: _HtmlContext, raw: String): String
+
+
+primitive _HtmlEscapingRenderer is _RenderableValue
+  """
+  Applies context-appropriate HTML escaping. This is the default renderer
+  for template values used with `HtmlTemplate`.
+  """
+  fun val render(context: _HtmlContext, raw: String): String =>
+    _HtmlEscape.for_context(context, raw)
+
+
+primitive _NoEscapeRenderer is _RenderableValue
+  """
+  Returns content unchanged, bypassing auto-escaping. Used for values
+  explicitly marked as unescaped via `TemplateValue.unescaped`.
+  """
+  fun val render(context: _HtmlContext, raw: String): String =>
+    raw


### PR DESCRIPTION
Internal components for the upcoming `HtmlTemplate` feature (PR 3). No public API changes — all new types are package-private.

- `_HtmlContextTracker`: Character-by-character HTML state machine tracking position within HTML structure (text, tag, attribute values, script, style, comment, RCDATA). Determines context-appropriate escaping at template insertion points.
- `_HtmlEscape`: Context-aware escaping for HTML text, attributes, URLs (with dangerous scheme filtering via prefix checks), JavaScript strings, CSS values, comments, and RCDATA.
- `_RenderableValue` interface with `_HtmlEscapingRenderer` and `_NoEscapeRenderer` primitives — visitor pattern for template values to control their own escaping behavior.
- 35 new tests covering state transitions, escaping correctness, case-insensitive tag matching, URL false positives, control character escaping, and property-based invariant checks.

Design: #65