### PR TITLE
Add HTML-aware template engine with contextual auto-escaping

### DIFF
--- a/.release-notes/add-html-template.md
+++ b/.release-notes/add-html-template.md
@@ -1,0 +1,27 @@
+## Add HTML-aware template engine with contextual auto-escaping
+
+`HtmlTemplate` works like `Template` but automatically escapes variable output based on HTML context. A variable inside a `<p>` tag gets HTML entity escaping; inside an `href` attribute it gets URL scheme filtering and percent-encoding; inside an `onclick` attribute it gets JavaScript string escaping; and so on.
+
+```pony
+let t = HtmlTemplate.parse(
+  "<h1>{{ title }}</h1>\n<p>{{ message }}</p>")?
+
+let v = TemplateValues
+v("title") = "Hello & welcome"
+v("message") = "<script>alert('xss')</script>"
+
+t.render(v)?
+// <h1>Hello &amp; welcome</h1>
+// <p>&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;</p>
+```
+
+Parse-time validation rejects templates with variables in structurally invalid positions — inside tag names, unquoted attribute values, etc. — and verifies that `if`/`else` branches and loops preserve HTML context consistency.
+
+To bypass escaping for trusted content, use `TemplateValue.unescaped` or `TemplateValues.unescaped`:
+
+```pony
+let v = TemplateValues
+v.unescaped("bio", "<em>Trusted</em> HTML")
+```
+
+`HtmlTemplate` shares the same template syntax, `TemplateContext`, and `TemplateValues` as `Template`. The `RenderableValue` interface and `HtmlContext` type are public for custom escaping strategies.

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,3 +33,7 @@ Defines a base HTML layout with `{{ block head }}` and `{{ block content }}` sec
 ## [trim-example](trim-example/)
 
 Uses `{{-` and `-}}` trim markers to strip whitespace around tags. Shows how selective trimming produces clean, indentation-sensitive output (like YAML service lists) without unwanted blank lines from control flow tags.
+
+## [html-escaping-example](html-escaping-example/)
+
+Uses `HtmlTemplate` for automatic context-aware HTML escaping. Shows how variable output is escaped differently depending on HTML position (text content, URL attributes, etc.) and how to bypass escaping for trusted content with `TemplateValue.unescaped` and `TemplateValues.unescaped`.

--- a/examples/html-escaping-example/html-escaping-example.pony
+++ b/examples/html-escaping-example/html-escaping-example.pony
@@ -1,0 +1,61 @@
+// in your code this `use` statement would be:
+// use "templates"
+use "../../templates"
+
+actor Main
+  new create(env: Env) =>
+    // HtmlTemplate works exactly like Template but automatically escapes
+    // variable output based on HTML context.
+    let template =
+      try
+        HtmlTemplate.parse(
+          "<h1>{{ title }}</h1>\n"
+          + "<p>{{ message }}</p>\n"
+          + "<a href=\"{{ url }}\">{{ link_text }}</a>")?
+      else
+        env.err.print("Could not parse template :(")
+        env.exitcode(1)
+        return
+      end
+
+    // Values containing HTML special characters are escaped automatically.
+    let values = TemplateValues
+    values("title") = "Hello & welcome"
+    values("message") = "<script>alert('xss')</script>"
+    values("url") = "https://example.com/?q=a&b=c"
+    values("link_text") = "Click <here>"
+
+    try
+      env.out.print("--- Escaped output ---")
+      env.out.print(template.render(values)?)
+      // Output:
+      // <h1>Hello &amp; welcome</h1>
+      // <p>&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;</p>
+      // <a href="https://example.com/?q=a&amp;b=c">Click &lt;here&gt;</a>
+    else
+      env.err.print("Could not render template :(")
+      env.exitcode(1)
+      return
+    end
+
+    // To insert trusted HTML without escaping, use TemplateValue.unescaped
+    // or the TemplateValues.unescaped convenience method.
+    let values2 = TemplateValues
+    values2("title") = "Page Title"
+    values2.unescaped("message", "<em>This is <b>safe</b> HTML</em>")
+    values2("url") = "https://example.com"
+    values2("link_text") = "Home"
+
+    try
+      env.out.print("")
+      env.out.print("--- Unescaped output ---")
+      env.out.print(template.render(values2)?)
+      // Output:
+      // <h1>Page Title</h1>
+      // <p><em>This is <b>safe</b> HTML</em></p>
+      // <a href="https://example.com">Home</a>
+    else
+      env.err.print("Could not render template :(")
+      env.exitcode(1)
+      return
+    end

--- a/templates/_test.pony
+++ b/templates/_test.pony
@@ -246,6 +246,23 @@ actor \nodoc\ Main is TestList
     test(_TestHtmlEscapingRenderer)
     test(_TestNoEscapeRenderer)
 
+    // HtmlTemplate tests
+    test(_TestHtmlTemplateBasicEscaping)
+    test(_TestHtmlTemplateAttrEscaping)
+    test(_TestHtmlTemplateUrlEscaping)
+    test(_TestHtmlTemplateUnescaped)
+    test(_TestHtmlTemplateUnescapedConvenience)
+    test(_TestHtmlTemplatePipeEscaping)
+    test(_TestHtmlTemplateIfBranchConsistency)
+    test(_TestHtmlTemplateLoopPreservesContext)
+    test(_TestHtmlTemplateErrorInTagName)
+    test(_TestHtmlTemplateErrorUnquotedAttr)
+    test(_TestHtmlTemplateScriptContext)
+    test(_TestHtmlTemplateCommentContext)
+    test(_TestHtmlTemplateCssAttrContext)
+    test(_TestHtmlTemplateRcdataContext)
+    test(Property1UnitTest[String](_PropHtmlTemplateEscapesInText))
+
 
 // ---------------------------------------------------------------------------
 // Generators (Step 2)
@@ -3423,9 +3440,9 @@ class \nodoc\ iso _TestContextText is UnitTest
 
   fun apply(h: TestHelper) =>
     let t = _HtmlContextTracker
-    h.assert_is[_HtmlContext](_CtxText, t.context())
+    h.assert_is[HtmlContext](CtxText, t.context())
     t.feed("hello world")
-    h.assert_is[_HtmlContext](_CtxText, t.context())
+    h.assert_is[HtmlContext](CtxText, t.context())
 
 class \nodoc\ iso _TestContextTag is UnitTest
   fun name(): String => "HtmlContext: inside tag is error"
@@ -3433,7 +3450,7 @@ class \nodoc\ iso _TestContextTag is UnitTest
   fun apply(h: TestHelper) =>
     let t = _HtmlContextTracker
     t.feed("<div")
-    h.assert_is[_HtmlContext](_CtxError, t.context())
+    h.assert_is[HtmlContext](CtxError, t.context())
 
 class \nodoc\ iso _TestContextAttrDq is UnitTest
   fun name(): String => "HtmlContext: double-quoted attr value"
@@ -3441,10 +3458,10 @@ class \nodoc\ iso _TestContextAttrDq is UnitTest
   fun apply(h: TestHelper) =>
     let t = _HtmlContextTracker
     t.feed("<div class=\"")
-    h.assert_is[_HtmlContext](_CtxHtmlAttr, t.context())
+    h.assert_is[HtmlContext](CtxHtmlAttr, t.context())
     t.feed("foo\"")
     // After closing quote, back in tag
-    h.assert_is[_HtmlContext](_CtxError, t.context())
+    h.assert_is[HtmlContext](CtxError, t.context())
 
 class \nodoc\ iso _TestContextAttrSq is UnitTest
   fun name(): String => "HtmlContext: single-quoted attr value"
@@ -3452,7 +3469,7 @@ class \nodoc\ iso _TestContextAttrSq is UnitTest
   fun apply(h: TestHelper) =>
     let t = _HtmlContextTracker
     t.feed("<div class='")
-    h.assert_is[_HtmlContext](_CtxHtmlAttr, t.context())
+    h.assert_is[HtmlContext](CtxHtmlAttr, t.context())
 
 class \nodoc\ iso _TestContextUnqAttrError is UnitTest
   fun name(): String => "HtmlContext: unquoted attr value is error"
@@ -3461,10 +3478,10 @@ class \nodoc\ iso _TestContextUnqAttrError is UnitTest
     let t = _HtmlContextTracker
     t.feed("<div class=")
     // Before attr val, still error
-    h.assert_is[_HtmlContext](_CtxError, t.context())
+    h.assert_is[HtmlContext](CtxError, t.context())
     t.feed("x")
     // In unquoted attr val — error context
-    h.assert_is[_HtmlContext](_CtxError, t.context())
+    h.assert_is[HtmlContext](CtxError, t.context())
 
 class \nodoc\ iso _TestContextComment is UnitTest
   fun name(): String => "HtmlContext: HTML comment"
@@ -3473,10 +3490,10 @@ class \nodoc\ iso _TestContextComment is UnitTest
     let t = _HtmlContextTracker
     t.feed("<!--")
     t.feed_close_tag("<!--")
-    h.assert_is[_HtmlContext](_CtxComment, t.context())
+    h.assert_is[HtmlContext](CtxComment, t.context())
     t.feed(" comment text -->")
     t.feed_close_tag(" comment text -->")
-    h.assert_is[_HtmlContext](_CtxText, t.context())
+    h.assert_is[HtmlContext](CtxText, t.context())
 
 class \nodoc\ iso _TestContextScript is UnitTest
   fun name(): String => "HtmlContext: script tag"
@@ -3484,14 +3501,14 @@ class \nodoc\ iso _TestContextScript is UnitTest
   fun apply(h: TestHelper) =>
     let t = _HtmlContextTracker
     t.feed("<script>")
-    h.assert_is[_HtmlContext](_CtxScript, t.context())
+    h.assert_is[HtmlContext](CtxScript, t.context())
     t.feed("var x = 1;")
     t.feed_close_tag("var x = 1;")
-    h.assert_is[_HtmlContext](_CtxScript, t.context())
+    h.assert_is[HtmlContext](CtxScript, t.context())
     let closing = "</script>"
     t.feed(closing)
     t.feed_close_tag(closing)
-    h.assert_is[_HtmlContext](_CtxText, t.context())
+    h.assert_is[HtmlContext](CtxText, t.context())
 
 class \nodoc\ iso _TestContextStyle is UnitTest
   fun name(): String => "HtmlContext: style tag"
@@ -3499,11 +3516,11 @@ class \nodoc\ iso _TestContextStyle is UnitTest
   fun apply(h: TestHelper) =>
     let t = _HtmlContextTracker
     t.feed("<style>")
-    h.assert_is[_HtmlContext](_CtxStyle, t.context())
+    h.assert_is[HtmlContext](CtxStyle, t.context())
     let closing = "</style>"
     t.feed(closing)
     t.feed_close_tag(closing)
-    h.assert_is[_HtmlContext](_CtxText, t.context())
+    h.assert_is[HtmlContext](CtxText, t.context())
 
 class \nodoc\ iso _TestContextRcdata is UnitTest
   fun name(): String => "HtmlContext: title/textarea RCDATA"
@@ -3511,11 +3528,11 @@ class \nodoc\ iso _TestContextRcdata is UnitTest
   fun apply(h: TestHelper) =>
     let t = _HtmlContextTracker
     t.feed("<title>")
-    h.assert_is[_HtmlContext](_CtxRcdata, t.context())
+    h.assert_is[HtmlContext](CtxRcdata, t.context())
     let closing = "</title>"
     t.feed(closing)
     t.feed_close_tag(closing)
-    h.assert_is[_HtmlContext](_CtxText, t.context())
+    h.assert_is[HtmlContext](CtxText, t.context())
 
 class \nodoc\ iso _TestContextUrlAttr is UnitTest
   fun name(): String => "HtmlContext: URL attributes"
@@ -3523,7 +3540,7 @@ class \nodoc\ iso _TestContextUrlAttr is UnitTest
   fun apply(h: TestHelper) =>
     let t = _HtmlContextTracker
     t.feed("<a href=\"")
-    h.assert_is[_HtmlContext](_CtxUrlAttr, t.context())
+    h.assert_is[HtmlContext](CtxUrlAttr, t.context())
 
 class \nodoc\ iso _TestContextJsAttr is UnitTest
   fun name(): String => "HtmlContext: JS event attributes"
@@ -3531,7 +3548,7 @@ class \nodoc\ iso _TestContextJsAttr is UnitTest
   fun apply(h: TestHelper) =>
     let t = _HtmlContextTracker
     t.feed("<div onclick=\"")
-    h.assert_is[_HtmlContext](_CtxJsAttr, t.context())
+    h.assert_is[HtmlContext](CtxJsAttr, t.context())
 
 class \nodoc\ iso _TestContextCssAttr is UnitTest
   fun name(): String => "HtmlContext: style attribute"
@@ -3539,7 +3556,7 @@ class \nodoc\ iso _TestContextCssAttr is UnitTest
   fun apply(h: TestHelper) =>
     let t = _HtmlContextTracker
     t.feed("<div style=\"")
-    h.assert_is[_HtmlContext](_CtxCssAttr, t.context())
+    h.assert_is[HtmlContext](CtxCssAttr, t.context())
 
 class \nodoc\ iso _TestContextClone is UnitTest
   fun name(): String => "HtmlContext: clone preserves state"
@@ -3552,7 +3569,7 @@ class \nodoc\ iso _TestContextClone is UnitTest
     t.feed("foo\"")
     // Original advanced, clone stayed
     h.assert_false(t.eq(t2))
-    h.assert_is[_HtmlContext](_CtxHtmlAttr, t2.context())
+    h.assert_is[HtmlContext](CtxHtmlAttr, t2.context())
 
 class \nodoc\ iso _TestContextBranchConsistency is UnitTest
   fun name(): String => "HtmlContext: branch consistency check"
@@ -3580,19 +3597,19 @@ class \nodoc\ iso _TestContextCaseInsensitiveTags is UnitTest
   fun apply(h: TestHelper) =>
     let t1 = _HtmlContextTracker
     t1.feed("<SCRIPT>")
-    h.assert_is[_HtmlContext](_CtxScript, t1.context())
+    h.assert_is[HtmlContext](CtxScript, t1.context())
 
     let t2 = _HtmlContextTracker
     t2.feed("<Script>")
-    h.assert_is[_HtmlContext](_CtxScript, t2.context())
+    h.assert_is[HtmlContext](CtxScript, t2.context())
 
     let t3 = _HtmlContextTracker
     t3.feed("<STYLE>")
-    h.assert_is[_HtmlContext](_CtxStyle, t3.context())
+    h.assert_is[HtmlContext](CtxStyle, t3.context())
 
     let t4 = _HtmlContextTracker
     t4.feed("<TITLE>")
-    h.assert_is[_HtmlContext](_CtxRcdata, t4.context())
+    h.assert_is[HtmlContext](CtxRcdata, t4.context())
 
 class \nodoc\ iso _TestContextScriptWithAttrs is UnitTest
   fun name(): String => "HtmlContext: script tag with attributes"
@@ -3600,7 +3617,7 @@ class \nodoc\ iso _TestContextScriptWithAttrs is UnitTest
   fun apply(h: TestHelper) =>
     let t = _HtmlContextTracker
     t.feed("<script type=\"text/javascript\">")
-    h.assert_is[_HtmlContext](_CtxScript, t.context())
+    h.assert_is[HtmlContext](CtxScript, t.context())
 
 class \nodoc\ iso _TestContextClosingTag is UnitTest
   fun name(): String => "HtmlContext: closing tag returns to text"
@@ -3608,7 +3625,7 @@ class \nodoc\ iso _TestContextClosingTag is UnitTest
   fun apply(h: TestHelper) =>
     let t = _HtmlContextTracker
     t.feed("<div>hello</div>")
-    h.assert_is[_HtmlContext](_CtxText, t.context())
+    h.assert_is[HtmlContext](CtxText, t.context())
 
 class \nodoc\ iso _TestContextCaseInsensitiveClose is UnitTest
   fun name(): String => "HtmlContext: case-insensitive closing tags"
@@ -3616,11 +3633,11 @@ class \nodoc\ iso _TestContextCaseInsensitiveClose is UnitTest
   fun apply(h: TestHelper) =>
     let t = _HtmlContextTracker
     t.feed("<script>")
-    h.assert_is[_HtmlContext](_CtxScript, t.context())
+    h.assert_is[HtmlContext](CtxScript, t.context())
     let closing = "</SCRIPT>"
     t.feed(closing)
     t.feed_close_tag(closing)
-    h.assert_is[_HtmlContext](_CtxText, t.context())
+    h.assert_is[HtmlContext](CtxText, t.context())
 
 class \nodoc\ iso _TestContextCloseTagWhitespace is UnitTest
   fun name(): String => "HtmlContext: closing tag with whitespace before >"
@@ -3632,7 +3649,7 @@ class \nodoc\ iso _TestContextCloseTagWhitespace is UnitTest
     let closing1 = "</script >"
     t1.feed(closing1)
     t1.feed_close_tag(closing1)
-    h.assert_is[_HtmlContext](_CtxText, t1.context())
+    h.assert_is[HtmlContext](CtxText, t1.context())
 
     // Multiple whitespace chars
     let t2 = _HtmlContextTracker
@@ -3640,7 +3657,7 @@ class \nodoc\ iso _TestContextCloseTagWhitespace is UnitTest
     let closing2 = "</style\t\n >"
     t2.feed(closing2)
     t2.feed_close_tag(closing2)
-    h.assert_is[_HtmlContext](_CtxText, t2.context())
+    h.assert_is[HtmlContext](CtxText, t2.context())
 
     // No whitespace still works
     let t3 = _HtmlContextTracker
@@ -3648,7 +3665,7 @@ class \nodoc\ iso _TestContextCloseTagWhitespace is UnitTest
     let closing3 = "</script>"
     t3.feed(closing3)
     t3.feed_close_tag(closing3)
-    h.assert_is[_HtmlContext](_CtxText, t3.context())
+    h.assert_is[HtmlContext](CtxText, t3.context())
 
 class \nodoc\ iso _PropContextTextRoundtrip is Property1[String]
   fun name(): String => "HtmlContext: text without < stays in text state"
@@ -3667,7 +3684,7 @@ class \nodoc\ iso _PropContextTextRoundtrip is Property1[String]
   fun property(arg1: String, h: PropertyHelper) =>
     let t = _HtmlContextTracker
     t.feed(arg1)
-    h.assert_is[_HtmlContext](_CtxText, t.context())
+    h.assert_is[HtmlContext](CtxText, t.context())
 
 
 // ---------------------------------------------------------------------------
@@ -3787,7 +3804,7 @@ class \nodoc\ iso _TestEscapeErrorContext is UnitTest
 
   fun apply(h: TestHelper) =>
     let raw = "<script>alert('xss')</script>"
-    h.assert_eq[String](raw, _HtmlEscape.for_context(_CtxError, raw))
+    h.assert_eq[String](raw, _HtmlEscape.for_context(CtxError, raw))
 
 class \nodoc\ iso _PropEscapeHtmlNoUnescapedChars is Property1[String]
   fun name(): String =>
@@ -3879,12 +3896,236 @@ class \nodoc\ iso _TestHtmlEscapingRenderer is UnitTest
   fun name(): String => "RenderableValue: HtmlEscapingRenderer escapes"
 
   fun apply(h: TestHelper) =>
-    let result = _HtmlEscapingRenderer.render(_CtxText, "<script>")
+    let result = _HtmlEscapingRenderer.render(CtxText, "<script>")
     h.assert_eq[String]("&lt;script&gt;", result)
 
 class \nodoc\ iso _TestNoEscapeRenderer is UnitTest
   fun name(): String => "RenderableValue: NoEscapeRenderer passes through"
 
   fun apply(h: TestHelper) =>
-    let result = _NoEscapeRenderer.render(_CtxText, "<script>")
+    let result = _NoEscapeRenderer.render(CtxText, "<script>")
     h.assert_eq[String]("<script>", result)
+
+
+// ---------------------------------------------------------------------------
+// HtmlTemplate tests
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _TestHtmlTemplateBasicEscaping is UnitTest
+  fun name(): String => "HtmlTemplate: escapes variables in text context"
+
+  fun apply(h: TestHelper) =>
+    try
+      let t = HtmlTemplate.parse("<p>{{ name }}</p>")?
+      let v = TemplateValues
+      v("name") = "<script>alert('xss')</script>"
+      let result = t.render(v)?
+      h.assert_eq[String](
+        "<p>&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;</p>", result)
+    else
+      h.fail("unexpected error")
+    end
+
+class \nodoc\ iso _TestHtmlTemplateAttrEscaping is UnitTest
+  fun name(): String => "HtmlTemplate: escapes in attribute context"
+
+  fun apply(h: TestHelper) =>
+    try
+      let t = HtmlTemplate.parse("<div class=\"{{ cls }}\">hello</div>")?
+      let v = TemplateValues
+      v("cls") = "a\"b&c"
+      let result = t.render(v)?
+      h.assert_eq[String](
+        "<div class=\"a&#34;b&amp;c\">hello</div>", result)
+    else
+      h.fail("unexpected error")
+    end
+
+class \nodoc\ iso _TestHtmlTemplateUrlEscaping is UnitTest
+  fun name(): String => "HtmlTemplate: escapes in URL attribute context"
+
+  fun apply(h: TestHelper) =>
+    try
+      let t = HtmlTemplate.parse("<a href=\"{{ url }}\">link</a>")?
+      let v = TemplateValues
+      v("url") = "javascript:alert(1)"
+      let result = t.render(v)?
+      // Dangerous scheme should be replaced with #ZgotmplZ
+      h.assert_true(result.contains("#ZgotmplZ"))
+      h.assert_false(result.contains("javascript"))
+    else
+      h.fail("unexpected error")
+    end
+
+class \nodoc\ iso _TestHtmlTemplateUnescaped is UnitTest
+  fun name(): String => "HtmlTemplate: unescaped values bypass escaping"
+
+  fun apply(h: TestHelper) =>
+    try
+      let t = HtmlTemplate.parse("<p>{{ content }}</p>")?
+      let v = TemplateValues
+      v("content") = TemplateValue.unescaped("<em>bold</em>")
+      let result = t.render(v)?
+      h.assert_eq[String]("<p><em>bold</em></p>", result)
+    else
+      h.fail("unexpected error")
+    end
+
+class \nodoc\ iso _TestHtmlTemplateUnescapedConvenience is UnitTest
+  fun name(): String =>
+    "HtmlTemplate: TemplateValues.unescaped convenience method"
+
+  fun apply(h: TestHelper) =>
+    try
+      let t = HtmlTemplate.parse("<p>{{ content }}</p>")?
+      let v = TemplateValues
+      v.unescaped("content", "<em>bold</em>")
+      let result = t.render(v)?
+      h.assert_eq[String]("<p><em>bold</em></p>", result)
+    else
+      h.fail("unexpected error")
+    end
+
+class \nodoc\ iso _TestHtmlTemplatePipeEscaping is UnitTest
+  fun name(): String => "HtmlTemplate: pipe results are always escaped"
+
+  fun apply(h: TestHelper) =>
+    try
+      let t = HtmlTemplate.parse("<p>{{ name | upper }}</p>")?
+      let v = TemplateValues
+      v("name") = "<b>hi</b>"
+      let result = t.render(v)?
+      // Even after upper filter, output should be escaped
+      h.assert_true(result.contains("&lt;"))
+      h.assert_false(result.contains("<b>") or result.contains("<B>"))
+    else
+      h.fail("unexpected error")
+    end
+
+class \nodoc\ iso _TestHtmlTemplateIfBranchConsistency is UnitTest
+  fun name(): String =>
+    "HtmlTemplate: rejects inconsistent if/else branches"
+
+  fun apply(h: TestHelper) =>
+    // If-body opens a tag, else-body doesn't — inconsistent
+    try
+      HtmlTemplate.parse(
+        "{{ if x }}<div class=\"{{ else }}hello{{ end }}")?
+      h.fail("should have errored")
+    end
+
+class \nodoc\ iso _TestHtmlTemplateLoopPreservesContext is UnitTest
+  fun name(): String => "HtmlTemplate: rejects loop that changes context"
+
+  fun apply(h: TestHelper) =>
+    // Loop body opens a tag without closing it
+    try
+      HtmlTemplate.parse("{{ for x in items }}<div{{ end }}")?
+      h.fail("should have errored")
+    end
+
+class \nodoc\ iso _TestHtmlTemplateErrorInTagName is UnitTest
+  fun name(): String => "HtmlTemplate: rejects variable in tag name"
+
+  fun apply(h: TestHelper) =>
+    try
+      HtmlTemplate.parse("<{{ tag }}>hello</div>")?
+      h.fail("should have errored")
+    end
+
+class \nodoc\ iso _TestHtmlTemplateErrorUnquotedAttr is UnitTest
+  fun name(): String => "HtmlTemplate: rejects variable in unquoted attr"
+
+  fun apply(h: TestHelper) =>
+    try
+      HtmlTemplate.parse("<div class={{ cls }}>hello</div>")?
+      h.fail("should have errored")
+    end
+
+class \nodoc\ iso _TestHtmlTemplateScriptContext is UnitTest
+  fun name(): String => "HtmlTemplate: JS-escapes in script context"
+
+  fun apply(h: TestHelper) =>
+    try
+      let t = HtmlTemplate.parse(
+        "<script>var x = \"{{ val }}\";</script>")?
+      let v = TemplateValues
+      v("val") = "a\"b"
+      let result = t.render(v)?
+      // Should use JS escaping, not HTML escaping
+      h.assert_true(result.contains("\\\""))
+      h.assert_false(result.contains("&#34;"))
+    else
+      h.fail("unexpected error")
+    end
+
+class \nodoc\ iso _TestHtmlTemplateCommentContext is UnitTest
+  fun name(): String => "HtmlTemplate: strips dashes in comment context"
+
+  fun apply(h: TestHelper) =>
+    try
+      let t = HtmlTemplate.parse("<!-- {{ note }} -->")?
+      let v = TemplateValues
+      v("note") = "a--b"
+      let result = t.render(v)?
+      // Should strip -- sequences
+      h.assert_true(result.contains("ab"))
+      h.assert_false(result.contains("a--b"))
+    else
+      h.fail("unexpected error")
+    end
+
+class \nodoc\ iso _TestHtmlTemplateCssAttrContext is UnitTest
+  fun name(): String => "HtmlTemplate: CSS-escapes in style attribute"
+
+  fun apply(h: TestHelper) =>
+    try
+      let t = HtmlTemplate.parse("<div style=\"color: {{ color }}\">x</div>")?
+      let v = TemplateValues
+      v("color") = "red;} body{background:url(evil)}"
+      let result = t.render(v)?
+      // CSS escaping should prevent breaking out of the property value
+      h.assert_false(result.contains("}"))
+    else
+      h.fail("unexpected error")
+    end
+
+class \nodoc\ iso _TestHtmlTemplateRcdataContext is UnitTest
+  fun name(): String => "HtmlTemplate: RCDATA-escapes in title element"
+
+  fun apply(h: TestHelper) =>
+    try
+      let t = HtmlTemplate.parse("<title>{{ page_title }}</title>")?
+      let v = TemplateValues
+      v("page_title") = "A & B <script>"
+      let result = t.render(v)?
+      // RCDATA escaping: & and < are escaped, > left as-is for RCDATA
+      h.assert_true(result.contains("&amp;"))
+      h.assert_true(result.contains("&lt;"))
+      h.assert_false(result.contains("<script>"))
+    else
+      h.fail("unexpected error")
+    end
+
+class \nodoc\ iso _PropHtmlTemplateEscapesInText is Property1[String]
+  fun name(): String =>
+    "HtmlTemplate: rendered text never contains raw < or >"
+
+  fun gen(): Generator[String] =>
+    Generators.ascii(1, 50)
+
+  fun property(arg1: String, h: PropertyHelper) =>
+    try
+      let t = HtmlTemplate.parse("<p>{{ x }}</p>")?
+      let v = TemplateValues
+      v("x") = arg1
+      let result = t.render(v)?
+      // Strip the known wrapper to get just the escaped content
+      let inner: String val = result.substring(3, result.size().isize() - 4)
+      for c in inner.values() do
+        match c
+        | '<' => h.fail("unescaped < in output")
+        | '>' => h.fail("unescaped > in output")
+        end
+      end
+    end

--- a/templates/html_context.pony
+++ b/templates/html_context.pony
@@ -1,17 +1,38 @@
-primitive _CtxText
-primitive _CtxHtmlAttr
-primitive _CtxUrlAttr
-primitive _CtxJsAttr
-primitive _CtxCssAttr
-primitive _CtxScript
-primitive _CtxStyle
-primitive _CtxComment
-primitive _CtxRcdata
-primitive _CtxError
+primitive CtxText
+  """Normal text content between HTML tags."""
 
-type _HtmlContext is
-  ( _CtxText | _CtxHtmlAttr | _CtxUrlAttr | _CtxJsAttr | _CtxCssAttr
-  | _CtxScript | _CtxStyle | _CtxComment | _CtxRcdata | _CtxError )
+primitive CtxHtmlAttr
+  """Inside a quoted HTML attribute value (non-URL, non-event, non-style)."""
+
+primitive CtxUrlAttr
+  """Inside a quoted URL attribute value (`href`, `src`, `action`, etc.)."""
+
+primitive CtxJsAttr
+  """Inside a quoted JavaScript event-handler attribute (`onclick`, etc.)."""
+
+primitive CtxCssAttr
+  """Inside a quoted `style` attribute value."""
+
+primitive CtxScript
+  """Inside a `<script>` element body."""
+
+primitive CtxStyle
+  """Inside a `<style>` element body."""
+
+primitive CtxComment
+  """Inside an HTML comment (`<!-- ... -->`)."""
+
+primitive CtxRcdata
+  """Inside a raw-text element (`<title>`, `<textarea>`)."""
+
+primitive CtxError
+  """Invalid insertion point (tag name, unquoted attribute, etc.)."""
+
+// The HTML context at a variable insertion point, used by `RenderableValue`
+// implementations to select the appropriate escaping strategy.
+type HtmlContext is
+  ( CtxText | CtxHtmlAttr | CtxUrlAttr | CtxJsAttr | CtxCssAttr
+  | CtxScript | CtxStyle | CtxComment | CtxRcdata | CtxError )
 
 
 primitive _StateText
@@ -252,30 +273,30 @@ class _HtmlContextTracker
     end
     false
 
-  fun context(): _HtmlContext =>
+  fun context(): HtmlContext =>
     """
     Return the current escaping context based on state and attribute name.
     """
     match _state
-    | _StateText => _CtxText
+    | _StateText => CtxText
     | _StateDqAttrVal => _attr_context()
     | _StateSqAttrVal => _attr_context()
-    | _StateUnqAttrVal => _CtxError
-    | _StateScript => _CtxScript
-    | _StateStyle => _CtxStyle
-    | _StateComment => _CtxComment
-    | _StateRcdata => _CtxRcdata
-    | _StateTag => _CtxError
-    | _StateAttrName => _CtxError
-    | _StateAfterAttrName => _CtxError
-    | _StateBeforeAttrVal => _CtxError
+    | _StateUnqAttrVal => CtxError
+    | _StateScript => CtxScript
+    | _StateStyle => CtxStyle
+    | _StateComment => CtxComment
+    | _StateRcdata => CtxRcdata
+    | _StateTag => CtxError
+    | _StateAttrName => CtxError
+    | _StateAfterAttrName => CtxError
+    | _StateBeforeAttrVal => CtxError
     end
 
-  fun _attr_context(): _HtmlContext =>
-    if _is_url_attr() then _CtxUrlAttr
-    elseif _is_js_attr() then _CtxJsAttr
-    elseif _is_css_attr() then _CtxCssAttr
-    else _CtxHtmlAttr
+  fun _attr_context(): HtmlContext =>
+    if _is_url_attr() then CtxUrlAttr
+    elseif _is_js_attr() then CtxJsAttr
+    elseif _is_css_attr() then CtxCssAttr
+    else CtxHtmlAttr
     end
 
   fun _is_url_attr(): Bool =>

--- a/templates/html_escape.pony
+++ b/templates/html_escape.pony
@@ -1,19 +1,19 @@
 primitive _HtmlEscape
-  fun for_context(context: _HtmlContext, raw: String): String =>
+  fun for_context(context: HtmlContext, raw: String): String =>
     """
     Apply context-appropriate escaping to the raw string.
     """
     match context
-    | _CtxText => html_text(raw)
-    | _CtxHtmlAttr => html_attr(raw)
-    | _CtxUrlAttr => url_attr(raw)
-    | _CtxJsAttr => js_string(raw)
-    | _CtxCssAttr => css_value(raw)
-    | _CtxScript => js_string(raw)
-    | _CtxStyle => css_value(raw)
-    | _CtxComment => comment(raw)
-    | _CtxRcdata => rcdata(raw)
-    | _CtxError => raw
+    | CtxText => html_text(raw)
+    | CtxHtmlAttr => html_attr(raw)
+    | CtxUrlAttr => url_attr(raw)
+    | CtxJsAttr => js_string(raw)
+    | CtxCssAttr => css_value(raw)
+    | CtxScript => js_string(raw)
+    | CtxStyle => css_value(raw)
+    | CtxComment => comment(raw)
+    | CtxRcdata => rcdata(raw)
+    | CtxError => raw
     end
 
   fun html_text(raw: String): String val =>
@@ -201,28 +201,28 @@ primitive _HtmlEscape
     end
 
 
-interface val _RenderableValue
+interface val RenderableValue
   """
   Determines how a template value is rendered within an HTML context.
   The renderer passes the current HTML context and the raw string value;
   the implementation decides whether and how to escape.
   """
-  fun val render(context: _HtmlContext, raw: String): String
+  fun val render(context: HtmlContext, raw: String): String
 
 
-primitive _HtmlEscapingRenderer is _RenderableValue
+primitive _HtmlEscapingRenderer is RenderableValue
   """
   Applies context-appropriate HTML escaping. This is the default renderer
   for template values used with `HtmlTemplate`.
   """
-  fun val render(context: _HtmlContext, raw: String): String =>
+  fun val render(context: HtmlContext, raw: String): String =>
     _HtmlEscape.for_context(context, raw)
 
 
-primitive _NoEscapeRenderer is _RenderableValue
+primitive _NoEscapeRenderer is RenderableValue
   """
   Returns content unchanged, bypassing auto-escaping. Used for values
   explicitly marked as unescaped via `TemplateValue.unescaped`.
   """
-  fun val render(context: _HtmlContext, raw: String): String =>
+  fun val render(context: HtmlContext, raw: String): String =>
     raw

--- a/templates/html_template.pony
+++ b/templates/html_template.pony
@@ -1,0 +1,224 @@
+use "collections"
+use "files"
+use "valbytes"
+
+
+class val HtmlTemplate
+  """
+  An HTML-aware template engine with contextual auto-escaping.
+
+  `HtmlTemplate` uses the same template syntax as `Template` but automatically
+  escapes variable output based on HTML context. A variable inside a `<p>` tag
+  gets HTML entity escaping; inside an `href` attribute it gets URL escaping
+  and dangerous scheme filtering; inside an `onclick` attribute it gets
+  JavaScript string escaping; and so on.
+
+  Parse-time validation rejects templates with variables in structurally
+  invalid positions (inside tag names, unquoted attribute values, etc.) and
+  verifies that `if`/`else` branches and loops preserve HTML context
+  consistency.
+
+  To bypass auto-escaping for trusted content, use `TemplateValue.unescaped`
+  or `TemplateValues.unescaped`. Plain `Template` ignores the escaping
+  annotations entirely — they only take effect in `HtmlTemplate`.
+  """
+  let _parts: Array[_Part] box
+
+  new val parse(
+    source: String,
+    ctx: TemplateContext val = TemplateContext()
+  )? =>
+    """
+    Parse an HTML template from a string. Raises an error if the template
+    has syntax errors or if variables appear in invalid HTML positions
+    (tag names, unquoted attributes, etc.).
+    """
+    let parts = _ParserCommon.parse_template(source, ctx)?
+    _validate(parts)?
+    _parts = parts
+
+  new val from_file(
+    path: FilePath,
+    ctx: TemplateContext val = TemplateContext()
+  )? =>
+    """
+    Parse an HTML template from a file. Raises an error if the file cannot
+    be read, the template has syntax errors, or variables appear in invalid
+    HTML positions.
+    """
+    let chunk_size: USize = 1024 * 1024 * 1
+    match OpenFile(path)
+    | let file: File =>
+      var data = ByteArrays()
+      while file.errno() is FileOK do
+        data = data + file.read(chunk_size)
+      end
+      let parts = _ParserCommon.parse_template(data.string(), ctx)?
+      _validate(parts)?
+      _parts = parts
+    else error
+    end
+
+  fun render(values: TemplateValues box): String? =>
+    """
+    Render the template with the given values. Variable output is
+    automatically escaped based on HTML context unless the value was
+    created with `TemplateValue.unescaped`.
+    """
+    let tracker: _HtmlContextTracker ref = _HtmlContextTracker
+    _render_parts(_parts, values, tracker)?
+
+  fun tag _validate(parts: Array[_Part] box)? =>
+    let tracker: _HtmlContextTracker ref = _HtmlContextTracker
+    _validate_parts(parts, tracker)?
+
+  fun tag _validate_parts(
+    parts: Array[_Part] box,
+    tracker: _HtmlContextTracker ref
+  )? =>
+    for part in parts.values() do
+      match part
+      | (_Literal, let text: String) =>
+        tracker.feed(text)
+        tracker.feed_close_tag(text)
+      | let prop: _PropNode =>
+        _check_insertion_point(tracker)?
+      | let pipe: _Pipe box =>
+        _check_insertion_point(tracker)?
+      | let if': _If box =>
+        let before = tracker.clone()
+        _validate_parts(if'.body, tracker)?
+        match if'.else_body
+        | let eb: Array[_Part] box =>
+          let else_tracker = before.clone()
+          _validate_parts(eb, else_tracker)?
+          if not tracker.eq(else_tracker) then error end
+        else
+          // No else branch — if-body must preserve context
+          if not tracker.eq(before) then error end
+        end
+      | let ifnot: _IfNot box =>
+        let before = tracker.clone()
+        _validate_parts(ifnot.body, tracker)?
+        match ifnot.else_body
+        | let eb: Array[_Part] box =>
+          let else_tracker = before.clone()
+          _validate_parts(eb, else_tracker)?
+          if not tracker.eq(else_tracker) then error end
+        else
+          if not tracker.eq(before) then error end
+        end
+      | let loop: _Loop box =>
+        let before = tracker.clone()
+        _validate_parts(loop.body, tracker)?
+        if not tracker.eq(before) then error end
+      | let blk: _Block box =>
+        _validate_parts(blk.body, tracker)?
+      end
+    end
+
+  fun tag _check_insertion_point(tracker: _HtmlContextTracker box)? =>
+    match tracker.context()
+    | CtxError => error
+    end
+
+  fun tag _render_parts(
+    parts: Array[_Part] box,
+    values: TemplateValues box,
+    tracker: _HtmlContextTracker ref
+  ): String? =>
+    var result = ByteArrays()
+    for part in parts.values() do
+      match part
+      | (_Literal, let text: String) =>
+        tracker.feed(text)
+        tracker.feed_close_tag(text)
+        result = result + text
+      | let pipe: _Pipe box =>
+        var current: String = match pipe.source
+        | let s: String => s
+        | let p: _PropNode =>
+          try values._lookup(p)?.string()? else "" end
+        end
+        for (filter, args) in pipe.filters.values() do
+          match filter
+          | let f: Filter val =>
+            current = f(current)
+          | let f: Filter2 val =>
+            let a1 = try
+              match args(0)?
+              | let s: String => s
+              | let p: _PropNode =>
+                try values._lookup(p)?.string()? else "" end
+              end
+            else "" end
+            current = f(current, a1)
+          | let f: Filter3 val =>
+            let a1 = try
+              match args(0)?
+              | let s: String => s
+              | let p: _PropNode =>
+                try values._lookup(p)?.string()? else "" end
+              end
+            else "" end
+            let a2 = try
+              match args(1)?
+              | let s: String => s
+              | let p: _PropNode =>
+                try values._lookup(p)?.string()? else "" end
+              end
+            else "" end
+            current = f(current, a1, a2)
+          end
+        end
+        // Pipe results are always escaped — no TemplateValue to check
+        result = result + _HtmlEscapingRenderer.render(
+          tracker.context(), current)
+      | let prop: _PropNode =>
+        let tv = try values._lookup(prop)? else
+          // Missing value — render empty, same as Template
+          result = result + ""
+          continue
+        end
+        let raw = try tv.string()? else "" end
+        result = result + tv.renderable().render(tracker.context(), raw)
+      | let if': _If box =>
+        if
+          try
+            values._lookup(if'.value)?._is_truthy()
+          else
+            false
+          end
+        then
+          result = result + _render_parts(if'.body, values, tracker)?
+        else
+          match if'.else_body
+          | let eb: Array[_Part] box =>
+            result = result + _render_parts(eb, values, tracker)?
+          end
+        end
+      | let ifnot: _IfNot box =>
+        if
+          try
+            values._lookup(ifnot.value)?._is_truthy()
+          else
+            false
+          end
+        then
+          match ifnot.else_body
+          | let eb: Array[_Part] box =>
+            result = result + _render_parts(eb, values, tracker)?
+          end
+        else
+          result = result + _render_parts(ifnot.body, values, tracker)?
+        end
+      | let loop: _Loop box =>
+        for value in values._lookup(loop.source)?.values() do
+          let body_values = values._override(loop.target, value)
+          result = result + _render_parts(loop.body, body_values, tracker)?
+        end
+      | let blk: _Block box =>
+        result = result + _render_parts(blk.body, values, tracker)?
+      end
+    end
+    result.string()

--- a/templates/template.pony
+++ b/templates/template.pony
@@ -1,8 +1,17 @@
 """
-A simple text-based template engine.
+A text-based template engine with optional HTML auto-escaping.
 
-Templates are strings containing literal text interspersed with `{{ ... }}`
-blocks. Supported block types:
+Two template types are available:
+
+* `Template` renders values as-is, with no escaping. Suitable for plain text,
+  configuration files, or contexts where HTML safety is not a concern.
+* `HtmlTemplate` automatically escapes variable output based on HTML context —
+  text content gets entity escaping, URL attributes get scheme filtering and
+  percent-encoding, script contexts get JS string escaping, and so on.
+  Use `TemplateValue.unescaped` to bypass escaping for trusted content.
+
+Both types share the same template syntax. Templates are strings containing
+literal text interspersed with `{{ ... }}` blocks. Supported block types:
 
 * **Variable substitution**: `{{ name }}` or `{{ obj.prop }}`
 * **Conditionals**: `{{ if flag }}...{{ end }}`, with optional
@@ -161,9 +170,14 @@ class box TemplateValue
   """
   A value that can be used in a template. Either a single value or a
   sequence of values.
+
+  When used with `HtmlTemplate`, values are automatically escaped based on
+  their HTML context. To bypass escaping for trusted content, use the
+  `unescaped` constructor instead of `create`.
   """
   let _data: (String | Seq[TemplateValue] box)
   let _properties: Map[String, TemplateValue] box
+  let _renderable: RenderableValue
 
   new box create(
     value: (String | Seq[TemplateValue] box),
@@ -171,10 +185,38 @@ class box TemplateValue
   ) =>
     _data = value
     _properties = properties
+    _renderable = _HtmlEscapingRenderer
+
+  new box unescaped(
+    value: (String | Seq[TemplateValue] box),
+    properties: Map[String, TemplateValue] box = Map[String, TemplateValue]
+  ) =>
+    """
+    Create a value that bypasses HTML auto-escaping in `HtmlTemplate`.
+    The content is inserted as-is, without context-aware escaping. Use this
+    only for content you trust (e.g., pre-sanitized HTML fragments).
+
+    Has no effect when used with plain `Template`, which does not escape.
+
+    Note: the unescaped annotation applies only to direct variable
+    substitution (`{{ name }}`). When a value passes through a filter pipe
+    (`{{ name | upper }}`), the result is always escaped — filters could
+    introduce unsafe content.
+    """
+    _data = value
+    _properties = properties
+    _renderable = _NoEscapeRenderer
 
   fun apply(name: String): TemplateValue? => _properties(name)?
 
   fun string(): String? => _data as String
+
+  fun renderable(): RenderableValue =>
+    """
+    The rendering strategy for this value. `HtmlTemplate` calls this to
+    determine how to escape the value based on HTML context.
+    """
+    _renderable
 
   fun values(): Iterator[TemplateValue] =>
     match _data
@@ -227,6 +269,15 @@ class TemplateValues
     | let string: String => TemplateValue(string)
     | let template_value: TemplateValue => template_value
     end
+
+  fun ref unescaped(name: String, value: String) =>
+    """
+    Store a string value that bypasses HTML auto-escaping in `HtmlTemplate`.
+    See `TemplateValue.unescaped` for details. For structured values (with
+    properties or sequences), use `TemplateValue.unescaped()` directly and
+    pass the result to `update()`.
+    """
+    _values(name) = TemplateValue.unescaped(value)
 
   fun box _override(name: String, value: TemplateValue): TemplateValues =>
     let values = Map[String, TemplateValue]


### PR DESCRIPTION
HtmlTemplate reuses the existing parser but adds parse-time validation (branch consistency, insertion point checks) and render-time context-aware escaping via the RenderableValue interface. Values are escaped based on HTML context (text, attribute, URL, JS, CSS, comment, RCDATA). The TemplateValue.unescaped constructor bypasses escaping for trusted content.

The public API surface is intentionally minimal: HtmlTemplate class, RenderableValue interface, HtmlContext type alias, and context primitives. This keeps Template completely unaware of HTML concerns while giving advanced users the ability to implement custom escaping strategies.

Design: #65