### PR TITLE
Fix RCDATA closing tag matching wrong element

### DIFF
--- a/templates/_test.pony
+++ b/templates/_test.pony
@@ -3526,13 +3526,41 @@ class \nodoc\ iso _TestContextRcdata is UnitTest
   fun name(): String => "HtmlContext: title/textarea RCDATA"
 
   fun apply(h: TestHelper) =>
-    let t = _HtmlContextTracker
-    t.feed("<title>")
-    h.assert_is[HtmlContext](CtxRcdata, t.context())
-    let closing = "</title>"
-    t.feed(closing)
-    t.feed_close_tag(closing)
-    h.assert_is[HtmlContext](CtxText, t.context())
+    // <title> enters RCDATA and </title> exits it
+    let t1 = _HtmlContextTracker
+    t1.feed("<title>")
+    h.assert_is[HtmlContext](CtxRcdata, t1.context())
+    let closing1 = "</title>"
+    t1.feed(closing1)
+    t1.feed_close_tag(closing1)
+    h.assert_is[HtmlContext](CtxText, t1.context())
+
+    // <textarea> enters RCDATA and </textarea> exits it
+    let t2 = _HtmlContextTracker
+    t2.feed("<textarea>")
+    h.assert_is[HtmlContext](CtxRcdata, t2.context())
+    let closing2 = "</textarea>"
+    t2.feed(closing2)
+    t2.feed_close_tag(closing2)
+    h.assert_is[HtmlContext](CtxText, t2.context())
+
+    // </textarea> does NOT close a <title> RCDATA state
+    let t3 = _HtmlContextTracker
+    t3.feed("<title>")
+    h.assert_is[HtmlContext](CtxRcdata, t3.context())
+    let wrong1 = "</textarea>"
+    t3.feed(wrong1)
+    t3.feed_close_tag(wrong1)
+    h.assert_is[HtmlContext](CtxRcdata, t3.context())
+
+    // </title> does NOT close a <textarea> RCDATA state
+    let t4 = _HtmlContextTracker
+    t4.feed("<textarea>")
+    h.assert_is[HtmlContext](CtxRcdata, t4.context())
+    let wrong2 = "</title>"
+    t4.feed(wrong2)
+    t4.feed_close_tag(wrong2)
+    h.assert_is[HtmlContext](CtxRcdata, t4.context())
 
 class \nodoc\ iso _TestContextUrlAttr is UnitTest
   fun name(): String => "HtmlContext: URL attributes"

--- a/templates/html_context.pony
+++ b/templates/html_context.pony
@@ -44,15 +44,16 @@ primitive _StateDqAttrVal
 primitive _StateSqAttrVal
 primitive _StateUnqAttrVal
 primitive _StateComment
-primitive _StateRcdata
+primitive _StateRcdataTitle
+primitive _StateRcdataTextarea
 primitive _StateScript
 primitive _StateStyle
 
 type _HtmlState is
   ( _StateText | _StateTag | _StateAttrName | _StateAfterAttrName
   | _StateBeforeAttrVal | _StateDqAttrVal | _StateSqAttrVal
-  | _StateUnqAttrVal | _StateComment | _StateRcdata
-  | _StateScript | _StateStyle )
+  | _StateUnqAttrVal | _StateComment | _StateRcdataTitle
+  | _StateRcdataTextarea | _StateScript | _StateStyle )
 
 
 class _HtmlContextTracker
@@ -92,7 +93,8 @@ class _HtmlContextTracker
     | _StateSqAttrVal => if c == '\'' then _state = _StateTag end
     | _StateUnqAttrVal => _in_unq_attr_val(c)
     | _StateComment => _in_comment(c)
-    | _StateRcdata => _in_rcdata(c)
+    | _StateRcdataTitle => _in_rcdata(c)
+    | _StateRcdataTextarea => _in_rcdata(c)
     | _StateScript => _in_script(c)
     | _StateStyle => _in_style(c)
     end
@@ -206,8 +208,10 @@ class _HtmlContextTracker
       _state = _StateScript
     elseif (_tag_name == "style") then
       _state = _StateStyle
-    elseif (_tag_name == "title") or (_tag_name == "textarea") then
-      _state = _StateRcdata
+    elseif (_tag_name == "title") then
+      _state = _StateRcdataTitle
+    elseif (_tag_name == "textarea") then
+      _state = _StateRcdataTextarea
     else
       _state = _StateText
     end
@@ -230,10 +234,12 @@ class _HtmlContextTracker
       if _contains_close_tag(text, "style") then
         _state = _StateText
       end
-    | _StateRcdata =>
-      if _contains_close_tag(text, "title")
-        or _contains_close_tag(text, "textarea")
-      then
+    | _StateRcdataTitle =>
+      if _contains_close_tag(text, "title") then
+        _state = _StateText
+      end
+    | _StateRcdataTextarea =>
+      if _contains_close_tag(text, "textarea") then
         _state = _StateText
       end
     | _StateComment =>
@@ -285,7 +291,8 @@ class _HtmlContextTracker
     | _StateScript => CtxScript
     | _StateStyle => CtxStyle
     | _StateComment => CtxComment
-    | _StateRcdata => CtxRcdata
+    | _StateRcdataTitle => CtxRcdata
+    | _StateRcdataTextarea => CtxRcdata
     | _StateTag => CtxError
     | _StateAttrName => CtxError
     | _StateAfterAttrName => CtxError


### PR DESCRIPTION
`_StateRcdata` was a single state for both `<title>` and `<textarea>`, but `feed_close_tag` checked for either closing tag regardless of which one entered the state. This meant `</title>` inside a `<textarea>` (or vice versa) would incorrectly exit RCDATA mode.

Split into `_StateRcdataTitle` and `_StateRcdataTextarea`, mirroring how `_StateScript` and `_StateStyle` each have their own state. Both still map to `CtxRcdata` in `context()`.

Closes #69