### PR TITLE
Update README to document current feature set

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # templates
 
-A template engine for [Pony](https://www.ponylang.io/) with optional HTML-aware contextual auto-escaping.
+A template engine for Pony with optional HTML-aware contextual auto-escaping.
 
 ## Status
 


### PR DESCRIPTION
The README was substantially out of date — it described the library as alpha-level and was missing many features added since ~v0.2.0. This rewrites it to follow pony-library-readme conventions and document the full current API:

- Section order now matches convention (title, intro, Status, Installation, Usage, Supported Features, API Documentation)
- Status changed from alpha to beta
- Added Usage section with `Template` and `HtmlTemplate` code examples
- Supported Features updated to include: else/elseif branches, ifnot, template inheritance, comments, raw blocks, the title filter, string literal pipe sources, variable filter arguments, and HTML auto-escaping with `TemplateValues.unescaped`