### PR TITLE
Fix missing backtick escaping in JS string context

### DIFF
--- a/templates/_test.pony
+++ b/templates/_test.pony
@@ -258,6 +258,7 @@ actor \nodoc\ Main is TestList
     test(_TestHtmlTemplateErrorInTagName)
     test(_TestHtmlTemplateErrorUnquotedAttr)
     test(_TestHtmlTemplateScriptContext)
+    test(_TestHtmlTemplateScriptBacktick)
     test(_TestHtmlTemplateCommentContext)
     test(_TestHtmlTemplateCssAttrContext)
     test(_TestHtmlTemplateRcdataContext)
@@ -3761,6 +3762,7 @@ class \nodoc\ iso _TestEscapeJs is UnitTest
     h.assert_eq[String]("\\x3c", _HtmlEscape.js_string("<"))
     h.assert_eq[String]("\\x3e", _HtmlEscape.js_string(">"))
     h.assert_eq[String]("\\x26", _HtmlEscape.js_string("&"))
+    h.assert_eq[String]("\\x60", _HtmlEscape.js_string("`"))
     h.assert_eq[String]("hello", _HtmlEscape.js_string("hello"))
 
 class \nodoc\ iso _TestEscapeCss is UnitTest
@@ -4083,6 +4085,22 @@ class \nodoc\ iso _TestHtmlTemplateScriptContext is UnitTest
       // Should use JS escaping, not HTML escaping
       h.assert_true(result.contains("\\\""))
       h.assert_false(result.contains("&#34;"))
+    else
+      h.fail("unexpected error")
+    end
+
+class \nodoc\ iso _TestHtmlTemplateScriptBacktick is UnitTest
+  fun name(): String => "HtmlTemplate: escapes backticks in script context"
+
+  fun apply(h: TestHelper) =>
+    try
+      let t = HtmlTemplate.parse(
+        "<script>var x = \"{{ val }}\";</script>")?
+      let v = TemplateValues
+      v("val") = "a`b"
+      let result = t.render(v)?
+      h.assert_true(result.contains("\\x60"))
+      h.assert_false(result.contains("`"))
     else
       h.fail("unexpected error")
     end

--- a/templates/html_escape.pony
+++ b/templates/html_escape.pony
@@ -67,7 +67,7 @@ primitive _HtmlEscape
   fun js_string(raw: String): String val =>
     """
     Escape for JavaScript string context. Escapes backslash, quotes,
-    angle brackets, and non-ASCII to `\\xNN` / `\\uNNNN`.
+    backticks, angle brackets, and non-ASCII to `\\xNN` / `\\uNNNN`.
     """
     recover val
       let out = String(raw.size())
@@ -79,6 +79,7 @@ primitive _HtmlEscape
         | '<' => out.append("\\x3c")
         | '>' => out.append("\\x3e")
         | '&' => out.append("\\x26")
+        | '`' => out.append("\\x60")
         | '\n' => out.append("\\n")
         | '\r' => out.append("\\r")
         | '\t' => out.append("\\t")


### PR DESCRIPTION
The `js_string()` escaping function did not escape backticks (U+0060). Since backticks delimit JavaScript template literals (ES2015+), a value containing a backtick could break out of a template literal and inject arbitrary JavaScript. This is the same class of vulnerability as CVE-2023-24538 in Go's `html/template`.

Backticks are now escaped as `\x60`, consistent with how the function already hex-escapes other non-alphanumeric characters like `<` (`\x3c`), `>` (`\x3e`), and `&` (`\x26`).