### PR TITLE
Add public `scope()` method to TemplateValues

### DIFF
--- a/.release-notes/add-scope-method.md
+++ b/.release-notes/add-scope-method.md
@@ -1,0 +1,17 @@
+## Add public `scope()` method to TemplateValues
+
+`TemplateValues` now has a `scope()` method that creates an empty writable child scope backed by the receiver as a read-only parent. Writes go to the child; lookups that miss in the child fall through to the parent.
+
+```pony
+let parent = TemplateValues
+parent("name") = "Alice"
+
+let child = parent.scope()
+child("extra") = "new value"
+
+// child sees both its own values and the parent's
+child("extra")?.string()?  // => "new value"
+child("name")?.string()?   // => "Alice"
+```
+
+This is useful when you need a writable `TemplateValues` that inherits existing assigns without copying data or modifying the original. For example, composing component HTML into a template when the backing values are seen as `box` through viewpoint adaptation.

--- a/templates/_test.pony
+++ b/templates/_test.pony
@@ -24,6 +24,16 @@ actor \nodoc\ Main is TestList
     test(Property1UnitTest[(String, String, String)](
       _PropTemplateValuesOverrideShadows))
 
+    // TemplateValues.scope() tests
+    test(_TestTemplateValuesScopeEmpty)
+    test(_TestTemplateValuesScopeFallthrough)
+    test(_TestTemplateValuesScopeShadow)
+    test(_TestTemplateValuesScopeMultiLevel)
+    test(Property1UnitTest[(String, String)](
+      _PropTemplateValuesScopeFallthrough))
+    test(Property1UnitTest[(String, String, String)](
+      _PropTemplateValuesScopeShadows))
+
     // Parser tests (Step 4)
     test(Property1UnitTest[String](_PropValidPropParsesToPropNode))
     test(Property1UnitTest[String](_PropValidPipeParsesToPipeNode))
@@ -736,6 +746,117 @@ class \nodoc\ iso _PropTemplateValuesOverrideShadows
     parent(n) = parent_val
     let child = parent._override(n, TemplateValue(child_val))
     h.assert_eq[String](child_val, child(n)?.string()?)
+
+
+// ---------------------------------------------------------------------------
+// TemplateValues.scope() tests
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _TestTemplateValuesScopeEmpty is UnitTest
+  fun name(): String => "TemplateValues scope: empty child is writable"
+
+  fun apply(h: TestHelper)? =>
+    let parent = TemplateValues
+    let child = parent.scope()
+    child("key") = "value"
+    h.assert_eq[String]("value", child("key")?.string()?)
+
+
+class \nodoc\ iso _TestTemplateValuesScopeFallthrough is UnitTest
+  fun name(): String => "TemplateValues scope: lookups fall through to parent"
+
+  fun apply(h: TestHelper)? =>
+    let parent = TemplateValues
+    parent("color") = "blue"
+    let child = parent.scope()
+    h.assert_eq[String]("blue", child("color")?.string()?)
+
+
+class \nodoc\ iso _TestTemplateValuesScopeShadow is UnitTest
+  fun name(): String => "TemplateValues scope: child shadows parent"
+
+  fun apply(h: TestHelper)? =>
+    let parent = TemplateValues
+    parent("key") = "parent_value"
+    let child = parent.scope()
+    child("key") = "child_value"
+
+    // Child sees its own value
+    h.assert_eq[String]("child_value", child("key")?.string()?)
+    // Parent is unchanged
+    h.assert_eq[String]("parent_value", parent("key")?.string()?)
+
+
+class \nodoc\ iso _TestTemplateValuesScopeMultiLevel is UnitTest
+  fun name(): String => "TemplateValues scope: multi-level chain"
+
+  fun apply(h: TestHelper)? =>
+    let grandparent = TemplateValues
+    grandparent("a") = "from_grandparent"
+    let parent = grandparent.scope()
+    parent("b") = "from_parent"
+    let child = parent.scope()
+    child("c") = "from_child"
+
+    // Child sees all three levels
+    h.assert_eq[String]("from_grandparent", child("a")?.string()?)
+    h.assert_eq[String]("from_parent", child("b")?.string()?)
+    h.assert_eq[String]("from_child", child("c")?.string()?)
+
+    // Missing key errors through entire chain
+    h.assert_error({() ? =>
+      let gp = TemplateValues
+      let p = gp.scope()
+      let c = p.scope()
+      c("missing")?
+    })
+
+
+class \nodoc\ iso _PropTemplateValuesScopeFallthrough
+  is Property1[(String, String)]
+  fun name(): String =>
+    "TemplateValues scope: parent values readable from child"
+
+  fun gen(): Generator[(String, String)] =>
+    Generators.zip2[String, String](
+      _Generators.valid_name(),
+      _Generators.template_value_string())
+
+  fun ref property(
+    sample: (String, String),
+    h: PropertyHelper)
+  ? =>
+    (let n, let v) = sample
+    let parent = TemplateValues
+    parent(n) = v
+    let child = parent.scope()
+    h.assert_eq[String](v, child(n)?.string()?)
+
+
+class \nodoc\ iso _PropTemplateValuesScopeShadows
+  is Property1[(String, String, String)]
+  fun name(): String =>
+    "TemplateValues scope: child shadows parent, parent unchanged"
+
+  fun gen(): Generator[(String, String, String)] =>
+    Generators.zip3[String, String, String](
+      _Generators.valid_name(),
+      _Generators.template_value_string(),
+      _Generators.template_value_string())
+
+  fun ref property(
+    sample: (String, String, String),
+    h: PropertyHelper)
+  ? =>
+    (let n, let parent_val, let child_val) = sample
+    let parent = TemplateValues
+    parent(n) = parent_val
+    let child = parent.scope()
+    child(n) = child_val
+    // Child sees child value
+    h.assert_eq[String](child_val, child(n)?.string()?)
+    // Parent retains original
+    h.assert_eq[String](parent_val, parent(n)?.string()?)
 
 
 // ---------------------------------------------------------------------------

--- a/templates/template.pony
+++ b/templates/template.pony
@@ -232,6 +232,14 @@ class box TemplateValue
 
 
 class TemplateValues
+  """
+  A scoped key-value store for template rendering. Values are stored as
+  `TemplateValue` entries and looked up by name. Lookups check the local
+  scope first, then walk up the parent chain.
+
+  Use `scope()` to create a writable child that inherits all values from
+  this set without copying. Use `update()` and `unescaped()` to add values.
+  """
   let _parent: (TemplateValues box | None)
   let _values: Map[String, TemplateValue]
 
@@ -265,6 +273,11 @@ class TemplateValues
     value
 
   fun ref update(name: String, value: (String | TemplateValue)) =>
+    """
+    Store a value under the given name. String values are wrapped in a
+    `TemplateValue` automatically. This is also the target of Pony's
+    sugar for `values("key") = "value"`.
+    """
     _values(name) = match value
     | let string: String => TemplateValue(string)
     | let template_value: TemplateValue => template_value
@@ -278,6 +291,14 @@ class TemplateValues
     pass the result to `update()`.
     """
     _values(name) = TemplateValue.unescaped(value)
+
+  fun box scope(): TemplateValues =>
+    """
+    Create an empty writable child scope backed by this value set as a
+    read-only parent. Writes go to the child; lookups that miss in the
+    child fall through to the parent.
+    """
+    TemplateValues._create(this, Map[String, TemplateValue])
 
   fun box _override(name: String, value: TemplateValue): TemplateValues =>
     let values = Map[String, TemplateValue]


### PR DESCRIPTION
TemplateValues already supports parent-scoped lookup internally via the package-private `_create` constructor (used by `_override` for loop variables). `scope()` exposes this as a public API: it creates an empty writable child backed by the receiver as a read-only parent, so lookups that miss in the child fall through to the parent chain.

The motivating use case is livery's `LiveView.render`, where the backing `TemplateValues` is seen as `box` through viewpoint adaptation. `scope()` lets the view get a writable `TemplateValues` that inherits existing assigns without copying data or modifying the original.

Closes #76